### PR TITLE
bugfix: hex() to Microsoft GUID

### DIFF
--- a/LnkParse3/decorators.py
+++ b/LnkParse3/decorators.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from datetime import timezone
 from struct import unpack
 import functools
+import warnings
 from LnkParse3.lnk_exception import LnkException
 
 
@@ -11,12 +12,9 @@ def must_be(expected):
         def inner(self, *args, **kwargs):
             result = func(self, *args, **kwargs)
 
-            # FIXME: delete
-            return result
-
             if result != expected:
-                error = "%s must be %s: %s" % (func.__name__, expected, result)
-                raise LnkException(error)
+                msg = "%s must be %s: %s" % (func.__name__, expected, result)
+                warnings.warn(msg)
 
             return result
 
@@ -29,9 +27,6 @@ def uuid(func):
     @functools.wraps(func)
     def inner(self, *args, **kwargs):
         binary = func(self, *args, **kwargs)
-
-        # FIXME: delete
-        return binary.hex()
 
         # UUID variants
         # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/49e490b8-f972-45d6-a3a4-99f924998d97

--- a/LnkParse3/lnk_file.py
+++ b/LnkParse3/lnk_file.py
@@ -182,7 +182,13 @@ class LnkFile(object):
             return obj
 
         print(
-            json.dumps(res, indent=4, separators=(",", ": "), default=_datetime_to_str)
+            json.dumps(
+                res,
+                indent=4,
+                separators=(",", ": "),
+                default=_datetime_to_str,
+                sort_keys=True,
+            )
         )
 
     def get_json(self, get_all=False):

--- a/tests/json/lnk_failing.lnk.json
+++ b/tests/json/lnk_failing.lnk.json
@@ -4,10 +4,10 @@
     },
     "extra": {
         "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "birth_droid_file_identifier": "263d6343a986ea119c2db8aeed8e1a7a",
-            "birth_droid_volume_identifier": "70352df1c203e34386fcc75d680751b6",
-            "droid_file_identifier": "263d6343a986ea119c2db8aeed8e1a7a",
-            "droid_volume_identifier": "70352df1c203e34386fcc75d680751b6",
+            "birth_droid_file_identifier": "43633D26-86A9-11EA-9C2D-0000FDAE1A7A",
+            "birth_droid_volume_identifier": "F12D3570-03C2-43E3-86FC-0000EF5F51B6",
+            "droid_file_identifier": "43633D26-86A9-11EA-9C2D-0000FDAE1A7A",
+            "droid_volume_identifier": "F12D3570-03C2-43E3-86FC-0000EF5F51B6",
             "length": 88,
             "machine_identifier": "desktop-eie2fiq",
             "size": 96,
@@ -19,7 +19,7 @@
             "target_unicode": "C"
         },
         "METADATA_PROPERTIES_BLOCK": {
-            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "format_id": "DABD30ED-0043-4789-A7F8-0000F4736622",
             "size": 495,
             "storage_size": 125,
             "version": "0x53505331"
@@ -32,7 +32,7 @@
             "FILE_ATTRIBUTE_DIRECTORY"
         ],
         "file_size": 12288,
-        "guid": "0114020000000000c000000000000046",
+        "guid": "00021401-0000-0000-C000-000000000046",
         "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
         "icon_index": 0,
@@ -78,7 +78,7 @@
         "items": [
             {
                 "class": "Root Folder",
-                "guid": "471a0359723fa74489c55595fe6b30ee",
+                "guid": "59031A47-3F72-44A7-89C5-0000FFFF30EE",
                 "sort_index": "Users"
             },
             null,

--- a/tests/json/lnk_failing.lnk.json
+++ b/tests/json/lnk_failing.lnk.json
@@ -1,20 +1,41 @@
 {
+    "data": {
+        "relative_path": "..\\AppData\\Roaming\\.minecraft"
+    },
+    "extra": {
+        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
+            "birth_droid_file_identifier": "263d6343a986ea119c2db8aeed8e1a7a",
+            "birth_droid_volume_identifier": "70352df1c203e34386fcc75d680751b6",
+            "droid_file_identifier": "263d6343a986ea119c2db8aeed8e1a7a",
+            "droid_volume_identifier": "70352df1c203e34386fcc75d680751b6",
+            "length": 88,
+            "machine_identifier": "desktop-eie2fiq",
+            "size": 96,
+            "version": 0
+        },
+        "ENVIRONMENTAL_VARIABLES_LOCATION_BLOCK": {
+            "size": 788,
+            "target_ansi": "C:\\Users\\%USERNAME%\\AppData\\Roaming\\.minecraft",
+            "target_unicode": "C"
+        },
+        "METADATA_PROPERTIES_BLOCK": {
+            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "size": 495,
+            "storage_size": 125,
+            "version": "0x53505331"
+        }
+    },
     "header": {
-        "header_size": 76,
-        "guid": "0114020000000000c000000000000046",
-        "r_link_flags": 524939,
-        "r_file_flags": 16,
-        "creation_time": "2018-08-30T23:42:23.464049+00:00",
         "accessed_time": "2020-04-26T10:29:23.293963+00:00",
-        "modified_time": "2020-04-26T10:29:23.293963+00:00",
+        "creation_time": "2018-08-30T23:42:23.464049+00:00",
+        "file_flags": [
+            "FILE_ATTRIBUTE_DIRECTORY"
+        ],
         "file_size": 12288,
-        "icon_index": 0,
-        "windowstyle": "SW_NORMAL",
+        "guid": "0114020000000000c000000000000046",
+        "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
-        "r_hotkey": 0,
-        "reserved0": 0,
-        "reserved1": 0,
-        "reserved2": 0,
+        "icon_index": 0,
         "link_flags": [
             "HasTargetIDList",
             "HasLinkInfo",
@@ -23,82 +44,61 @@
             "HasExpString",
             "EnableTargetMetadata"
         ],
-        "file_flags": [
-            "FILE_ATTRIBUTE_DIRECTORY"
-        ]
+        "modified_time": "2020-04-26T10:29:23.293963+00:00",
+        "r_file_flags": 16,
+        "r_hotkey": 0,
+        "r_link_flags": 524939,
+        "reserved0": 0,
+        "reserved1": 0,
+        "reserved2": 0,
+        "windowstyle": "SW_NORMAL"
     },
-    "data": {
-        "relative_path": "..\\AppData\\Roaming\\.minecraft"
+    "link_info": {
+        "common_network_relative_link_offset": 0,
+        "common_path_suffix": "",
+        "common_path_suffix_offset": 90,
+        "link_info_flags": 1,
+        "link_info_header_size": 28,
+        "link_info_size": 91,
+        "local_base_path": "C:\\Users\\Jonathan\\AppData\\Roaming\\.minecraft",
+        "local_base_path_offset": 45,
+        "location": "Local",
+        "location_info": {
+            "drive_serial_number": "0x9e31fc72",
+            "drive_type": "DRIVE_FIXED",
+            "r_drive_type": 3,
+            "volume_id_size": 17,
+            "volume_label": "",
+            "volume_label_offset": 16
+        },
+        "volume_id_offset": 28
     },
     "target": {
-        "size": 372,
+        "index": 78,
         "items": [
             {
                 "class": "Root Folder",
-                "sort_index": "Users",
-                "guid": "471a0359723fa74489c55595fe6b30ee"
+                "guid": "471a0359723fa74489c55595fe6b30ee",
+                "sort_index": "Users"
             },
             null,
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "2001-06-04T10:04:32+00:00",
                 "file_attribute_flags": 48,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "2001-06-04T10:04:32+00:00",
                 "primary_name": "Roaming"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "Invalid time",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "Invalid time",
                 "primary_name": ".minecraft"
             }
         ],
-        "index": 78
-    },
-    "link_info": {
-        "link_info_size": 91,
-        "link_info_header_size": 28,
-        "link_info_flags": 1,
-        "volume_id_offset": 28,
-        "local_base_path_offset": 45,
-        "common_network_relative_link_offset": 0,
-        "common_path_suffix_offset": 90,
-        "local_base_path": "C:\\Users\\Jonathan\\AppData\\Roaming\\.minecraft",
-        "common_path_suffix": "",
-        "location": "Local",
-        "location_info": {
-            "volume_id_size": 17,
-            "r_drive_type": 3,
-            "drive_serial_number": "0x9e31fc72",
-            "volume_label_offset": 16,
-            "drive_type": "DRIVE_FIXED",
-            "volume_label": ""
-        }
-    },
-    "extra": {
-        "ENVIRONMENTAL_VARIABLES_LOCATION_BLOCK": {
-            "size": 788,
-            "target_ansi": "C:\\Users\\%USERNAME%\\AppData\\Roaming\\.minecraft",
-            "target_unicode": "C"
-        },
-        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "size": 96,
-            "length": 88,
-            "version": 0,
-            "machine_identifier": "desktop-eie2fiq",
-            "droid_volume_identifier": "70352df1c203e34386fcc75d680751b6",
-            "droid_file_identifier": "263d6343a986ea119c2db8aeed8e1a7a",
-            "birth_droid_volume_identifier": "70352df1c203e34386fcc75d680751b6",
-            "birth_droid_file_identifier": "263d6343a986ea119c2db8aeed8e1a7a"
-        },
-        "METADATA_PROPERTIES_BLOCK": {
-            "size": 495,
-            "storage_size": 125,
-            "version": "0x53505331",
-            "format_id": "ed30bdda43008947a7f8d013a4736622"
-        }
+        "size": 372
     }
 }

--- a/tests/json/lnk_failing2.lnk.json
+++ b/tests/json/lnk_failing2.lnk.json
@@ -4,17 +4,17 @@
     },
     "extra": {
         "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "birth_droid_file_identifier": "33ea6cf917dcea1181b984a93e87eae5",
-            "birth_droid_volume_identifier": "d626515ea77d3048a4ed3551991d2d5c",
-            "droid_file_identifier": "33ea6cf917dcea1181b984a93e87eae5",
-            "droid_volume_identifier": "d626515ea77d3048a4ed3551991d2d5c",
+            "birth_droid_file_identifier": "F96CEA33-DC17-11EA-81B9-0000BEAFEAE5",
+            "birth_droid_volume_identifier": "5E5126D6-7DA7-4830-A4ED-0000BD5D2D5C",
+            "droid_file_identifier": "F96CEA33-DC17-11EA-81B9-0000BEAFEAE5",
+            "droid_volume_identifier": "5E5126D6-7DA7-4830-A4ED-0000BD5D2D5C",
             "length": 88,
             "machine_identifier": "desktop-1dic5tp",
             "size": 96,
             "version": 0
         },
         "METADATA_PROPERTIES_BLOCK": {
-            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "format_id": "DABD30ED-0043-4789-A7F8-0000F4736622",
             "size": 417,
             "storage_size": 109,
             "version": "0x53505331"
@@ -27,7 +27,7 @@
             "FILE_ATTRIBUTE_DIRECTORY"
         ],
         "file_size": 4096,
-        "guid": "0114020000000000c000000000000046",
+        "guid": "00021401-0000-0000-C000-000000000046",
         "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
         "icon_index": 0,
@@ -72,7 +72,7 @@
         "items": [
             {
                 "class": "Root Folder",
-                "guid": "471a0359723fa74489c55595fe6b30ee",
+                "guid": "59031A47-3F72-44A7-89C5-0000FFFF30EE",
                 "sort_index": "Users"
             },
             null,

--- a/tests/json/lnk_failing2.lnk.json
+++ b/tests/json/lnk_failing2.lnk.json
@@ -1,20 +1,36 @@
 {
+    "data": {
+        "relative_path": "..\\.."
+    },
+    "extra": {
+        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
+            "birth_droid_file_identifier": "33ea6cf917dcea1181b984a93e87eae5",
+            "birth_droid_volume_identifier": "d626515ea77d3048a4ed3551991d2d5c",
+            "droid_file_identifier": "33ea6cf917dcea1181b984a93e87eae5",
+            "droid_volume_identifier": "d626515ea77d3048a4ed3551991d2d5c",
+            "length": 88,
+            "machine_identifier": "desktop-1dic5tp",
+            "size": 96,
+            "version": 0
+        },
+        "METADATA_PROPERTIES_BLOCK": {
+            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "size": 417,
+            "storage_size": 109,
+            "version": "0x53505331"
+        }
+    },
     "header": {
-        "header_size": 76,
-        "guid": "0114020000000000c000000000000046",
-        "r_link_flags": 524427,
-        "r_file_flags": 16,
-        "creation_time": "2020-08-11T21:18:01.637866+00:00",
         "accessed_time": "2020-08-11T23:05:58.474459+00:00",
-        "modified_time": "2020-08-11T23:05:58.369451+00:00",
+        "creation_time": "2020-08-11T21:18:01.637866+00:00",
+        "file_flags": [
+            "FILE_ATTRIBUTE_DIRECTORY"
+        ],
         "file_size": 4096,
-        "icon_index": 0,
-        "windowstyle": "SW_NORMAL",
+        "guid": "0114020000000000c000000000000046",
+        "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
-        "r_hotkey": 0,
-        "reserved0": 0,
-        "reserved1": 0,
-        "reserved2": 0,
+        "icon_index": 0,
         "link_flags": [
             "HasTargetIDList",
             "HasLinkInfo",
@@ -22,77 +38,61 @@
             "IsUnicode",
             "EnableTargetMetadata"
         ],
-        "file_flags": [
-            "FILE_ATTRIBUTE_DIRECTORY"
-        ]
+        "modified_time": "2020-08-11T23:05:58.369451+00:00",
+        "r_file_flags": 16,
+        "r_hotkey": 0,
+        "r_link_flags": 524427,
+        "reserved0": 0,
+        "reserved1": 0,
+        "reserved2": 0,
+        "windowstyle": "SW_NORMAL"
     },
-    "data": {
-        "relative_path": "..\\.."
+    "link_info": {
+        "common_network_relative_link_offset": 0,
+        "common_path_suffix": "",
+        "common_path_suffix_offset": 93,
+        "link_info_flags": 1,
+        "link_info_header_size": 28,
+        "link_info_size": 94,
+        "local_base_path": "C:\\Users\\TEMP\\AppData\\Roaming\\.minecraft",
+        "local_base_path_offset": 52,
+        "location": "Local",
+        "location_info": {
+            "drive_serial_number": "0x26a45a57",
+            "drive_type": "DRIVE_FIXED",
+            "r_drive_type": 3,
+            "volume_id_size": 24,
+            "volume_label": "Windows",
+            "volume_label_offset": 16
+        },
+        "volume_id_offset": 28
     },
     "target": {
-        "size": 372,
+        "index": 78,
         "items": [
             {
                 "class": "Root Folder",
-                "sort_index": "Users",
-                "guid": "471a0359723fa74489c55595fe6b30ee"
+                "guid": "471a0359723fa74489c55595fe6b30ee",
+                "sort_index": "Users"
             },
             null,
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "",
                 "primary_name": "Roaming"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "",
                 "primary_name": ".minecraft"
             }
         ],
-        "index": 78
-    },
-    "link_info": {
-        "link_info_size": 94,
-        "link_info_header_size": 28,
-        "link_info_flags": 1,
-        "volume_id_offset": 28,
-        "local_base_path_offset": 52,
-        "common_network_relative_link_offset": 0,
-        "common_path_suffix_offset": 93,
-        "local_base_path": "C:\\Users\\TEMP\\AppData\\Roaming\\.minecraft",
-        "common_path_suffix": "",
-        "location": "Local",
-        "location_info": {
-            "volume_id_size": 24,
-            "r_drive_type": 3,
-            "drive_serial_number": "0x26a45a57",
-            "volume_label_offset": 16,
-            "drive_type": "DRIVE_FIXED",
-            "volume_label": "Windows"
-        }
-    },
-    "extra": {
-        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "size": 96,
-            "length": 88,
-            "version": 0,
-            "machine_identifier": "desktop-1dic5tp",
-            "droid_volume_identifier": "d626515ea77d3048a4ed3551991d2d5c",
-            "droid_file_identifier": "33ea6cf917dcea1181b984a93e87eae5",
-            "birth_droid_volume_identifier": "d626515ea77d3048a4ed3551991d2d5c",
-            "birth_droid_file_identifier": "33ea6cf917dcea1181b984a93e87eae5"
-        },
-        "METADATA_PROPERTIES_BLOCK": {
-            "size": 417,
-            "storage_size": 109,
-            "version": "0x53505331",
-            "format_id": "ed30bdda43008947a7f8d013a4736622"
-        }
+        "size": 372
     }
 }

--- a/tests/json/lnk_failing3.lnk.json
+++ b/tests/json/lnk_failing3.lnk.json
@@ -2,7 +2,7 @@
     "data": {},
     "extra": {
         "METADATA_PROPERTIES_BLOCK": {
-            "format_id": "55284c9f799f394ba8d0e1d42de1d5f3",
+            "format_id": "9F4C2855-9F79-4B39-A8D0-0000EDF5D5F3",
             "size": 483,
             "storage_size": 471,
             "version": "0x53505331"
@@ -13,7 +13,7 @@
         "creation_time": "",
         "file_flags": [],
         "file_size": 0,
-        "guid": "0114020000000000c000000000000046",
+        "guid": "00021401-0000-0000-C000-000000000046",
         "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
         "icon_index": 0,
@@ -36,7 +36,7 @@
         "items": [
             {
                 "class": "Root Folder",
-                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "guid": "20D04FE0-3AEA-1069-A2D8-00002B30309D",
                 "sort_index": "My Computer"
             },
             {

--- a/tests/json/lnk_failing3.lnk.json
+++ b/tests/json/lnk_failing3.lnk.json
@@ -1,52 +1,52 @@
 {
+    "data": {},
+    "extra": {
+        "METADATA_PROPERTIES_BLOCK": {
+            "format_id": "55284c9f799f394ba8d0e1d42de1d5f3",
+            "size": 483,
+            "storage_size": 471,
+            "version": "0x53505331"
+        }
+    },
     "header": {
-        "header_size": 76,
-        "guid": "0114020000000000c000000000000046",
-        "r_link_flags": 129,
-        "r_file_flags": 0,
-        "creation_time": "",
         "accessed_time": "",
-        "modified_time": "",
+        "creation_time": "",
+        "file_flags": [],
         "file_size": 0,
-        "icon_index": 0,
-        "windowstyle": "SW_NORMAL",
+        "guid": "0114020000000000c000000000000046",
+        "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
-        "r_hotkey": 0,
-        "reserved0": 0,
-        "reserved1": 0,
-        "reserved2": 0,
+        "icon_index": 0,
         "link_flags": [
             "HasTargetIDList",
             "IsUnicode"
         ],
-        "file_flags": []
+        "modified_time": "",
+        "r_file_flags": 0,
+        "r_hotkey": 0,
+        "r_link_flags": 129,
+        "reserved0": 0,
+        "reserved1": 0,
+        "reserved2": 0,
+        "windowstyle": "SW_NORMAL"
     },
-    "data": {},
+    "link_info": {},
     "target": {
-        "size": 2556,
+        "index": 78,
         "items": [
             {
                 "class": "Root Folder",
-                "sort_index": "My Computer",
-                "guid": "e04fd020ea3a6910a2d808002b30309d"
+                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "sort_index": "My Computer"
             },
             {
                 "class": "Volume Item",
-                "flags": "0xe",
-                "data": ""
+                "data": "",
+                "flags": "0xe"
             },
             null,
             null
         ],
-        "index": 78
-    },
-    "link_info": {},
-    "extra": {
-        "METADATA_PROPERTIES_BLOCK": {
-            "size": 483,
-            "storage_size": 471,
-            "version": "0x53505331",
-            "format_id": "55284c9f799f394ba8d0e1d42de1d5f3"
-        }
+        "size": 2556
     }
 }

--- a/tests/json/lnk_failing4.lnk.json
+++ b/tests/json/lnk_failing4.lnk.json
@@ -4,17 +4,17 @@
     },
     "extra": {
         "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "birth_droid_file_identifier": "4b674d5a1ee5ea11ad33ad5d7ac210e4",
-            "birth_droid_volume_identifier": "8484a74ea555d7489e9bcba63e42b028",
-            "droid_file_identifier": "4b674d5a1ee5ea11ad33ad5d7ac210e4",
-            "droid_volume_identifier": "8484a74ea555d7489e9bcba63e42b028",
+            "birth_droid_file_identifier": "5A4D674B-E51E-11EA-AD33-0000FFDF10E4",
+            "birth_droid_volume_identifier": "4EA78484-55A5-48D7-9E9B-0000FFE6B028",
+            "droid_file_identifier": "5A4D674B-E51E-11EA-AD33-0000FFDF10E4",
+            "droid_volume_identifier": "4EA78484-55A5-48D7-9E9B-0000FFE6B028",
             "length": 88,
             "machine_identifier": "desktop-d6sjcfs",
             "size": 96,
             "version": 0
         },
         "METADATA_PROPERTIES_BLOCK": {
-            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "format_id": "DABD30ED-0043-4789-A7F8-0000F4736622",
             "size": 487,
             "storage_size": 125,
             "version": "0x53505331"
@@ -27,7 +27,7 @@
             "FILE_ATTRIBUTE_DIRECTORY"
         ],
         "file_size": 8192,
-        "guid": "0114020000000000c000000000000046",
+        "guid": "00021401-0000-0000-C000-000000000046",
         "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
         "icon_index": 0,
@@ -72,7 +72,7 @@
         "items": [
             {
                 "class": "Root Folder",
-                "guid": "471a0359723fa74489c55595fe6b30ee",
+                "guid": "59031A47-3F72-44A7-89C5-0000FFFF30EE",
                 "sort_index": "Users"
             },
             null,

--- a/tests/json/lnk_failing4.lnk.json
+++ b/tests/json/lnk_failing4.lnk.json
@@ -1,20 +1,36 @@
 {
+    "data": {
+        "relative_path": "..\\AppData\\Roaming\\.minecraft"
+    },
+    "extra": {
+        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
+            "birth_droid_file_identifier": "4b674d5a1ee5ea11ad33ad5d7ac210e4",
+            "birth_droid_volume_identifier": "8484a74ea555d7489e9bcba63e42b028",
+            "droid_file_identifier": "4b674d5a1ee5ea11ad33ad5d7ac210e4",
+            "droid_volume_identifier": "8484a74ea555d7489e9bcba63e42b028",
+            "length": 88,
+            "machine_identifier": "desktop-d6sjcfs",
+            "size": 96,
+            "version": 0
+        },
+        "METADATA_PROPERTIES_BLOCK": {
+            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "size": 487,
+            "storage_size": 125,
+            "version": "0x53505331"
+        }
+    },
     "header": {
-        "header_size": 76,
-        "guid": "0114020000000000c000000000000046",
-        "r_link_flags": 524427,
-        "r_file_flags": 16,
-        "creation_time": "2020-08-23T13:59:17.313516+00:00",
         "accessed_time": "2020-09-10T19:48:38.715254+00:00",
-        "modified_time": "2020-09-10T19:48:38.715254+00:00",
+        "creation_time": "2020-08-23T13:59:17.313516+00:00",
+        "file_flags": [
+            "FILE_ATTRIBUTE_DIRECTORY"
+        ],
         "file_size": 8192,
-        "icon_index": 0,
-        "windowstyle": "SW_NORMAL",
+        "guid": "0114020000000000c000000000000046",
+        "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
-        "r_hotkey": 0,
-        "reserved0": 0,
-        "reserved1": 0,
-        "reserved2": 0,
+        "icon_index": 0,
         "link_flags": [
             "HasTargetIDList",
             "HasLinkInfo",
@@ -22,77 +38,61 @@
             "IsUnicode",
             "EnableTargetMetadata"
         ],
-        "file_flags": [
-            "FILE_ATTRIBUTE_DIRECTORY"
-        ]
+        "modified_time": "2020-09-10T19:48:38.715254+00:00",
+        "r_file_flags": 16,
+        "r_hotkey": 0,
+        "r_link_flags": 524427,
+        "reserved0": 0,
+        "reserved1": 0,
+        "reserved2": 0,
+        "windowstyle": "SW_NORMAL"
     },
-    "data": {
-        "relative_path": "..\\AppData\\Roaming\\.minecraft"
+    "link_info": {
+        "common_network_relative_link_offset": 0,
+        "common_path_suffix": "",
+        "common_path_suffix_offset": 87,
+        "link_info_flags": 1,
+        "link_info_header_size": 28,
+        "link_info_size": 88,
+        "local_base_path": "C:\\Users\\roman\\AppData\\Roaming\\.minecraft",
+        "local_base_path_offset": 45,
+        "location": "Local",
+        "location_info": {
+            "drive_serial_number": "0xe68b5f22",
+            "drive_type": "DRIVE_FIXED",
+            "r_drive_type": 3,
+            "volume_id_size": 17,
+            "volume_label": "",
+            "volume_label_offset": 16
+        },
+        "volume_id_offset": 28
     },
     "target": {
-        "size": 372,
+        "index": 78,
         "items": [
             {
                 "class": "Root Folder",
-                "sort_index": "Users",
-                "guid": "471a0359723fa74489c55595fe6b30ee"
+                "guid": "471a0359723fa74489c55595fe6b30ee",
+                "sort_index": "Users"
             },
             null,
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "2066-08-04T10:09:08+00:00",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "2066-08-04T10:09:08+00:00",
                 "primary_name": "Roaming"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "Invalid time",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "Invalid time",
                 "primary_name": ".minecraft"
             }
         ],
-        "index": 78
-    },
-    "link_info": {
-        "link_info_size": 88,
-        "link_info_header_size": 28,
-        "link_info_flags": 1,
-        "volume_id_offset": 28,
-        "local_base_path_offset": 45,
-        "common_network_relative_link_offset": 0,
-        "common_path_suffix_offset": 87,
-        "local_base_path": "C:\\Users\\roman\\AppData\\Roaming\\.minecraft",
-        "common_path_suffix": "",
-        "location": "Local",
-        "location_info": {
-            "volume_id_size": 17,
-            "r_drive_type": 3,
-            "drive_serial_number": "0xe68b5f22",
-            "volume_label_offset": 16,
-            "drive_type": "DRIVE_FIXED",
-            "volume_label": ""
-        }
-    },
-    "extra": {
-        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "size": 96,
-            "length": 88,
-            "version": 0,
-            "machine_identifier": "desktop-d6sjcfs",
-            "droid_volume_identifier": "8484a74ea555d7489e9bcba63e42b028",
-            "droid_file_identifier": "4b674d5a1ee5ea11ad33ad5d7ac210e4",
-            "birth_droid_volume_identifier": "8484a74ea555d7489e9bcba63e42b028",
-            "birth_droid_file_identifier": "4b674d5a1ee5ea11ad33ad5d7ac210e4"
-        },
-        "METADATA_PROPERTIES_BLOCK": {
-            "size": 487,
-            "storage_size": 125,
-            "version": "0x53505331",
-            "format_id": "ed30bdda43008947a7f8d013a4736622"
-        }
+        "size": 372
     }
 }

--- a/tests/json/lnk_success.lnk.json
+++ b/tests/json/lnk_success.lnk.json
@@ -1,20 +1,38 @@
 {
+    "data": {
+        "command_line_arguments": "no_ipcheck - username=05551112233 password=123456",
+        "relative_path": ".\\AnonymusBrowser.exe",
+        "working_directory": "C:\\AnonymusBrowser-v2.0"
+    },
+    "extra": {
+        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
+            "birth_droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
+            "birth_droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
+            "droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
+            "droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
+            "length": 88,
+            "machine_identifier": "desktop-73cl5qt",
+            "size": 96,
+            "version": 0
+        },
+        "METADATA_PROPERTIES_BLOCK": {
+            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "size": 484,
+            "storage_size": 97,
+            "version": "0x53505331"
+        }
+    },
     "header": {
-        "header_size": 76,
-        "guid": "0114020000000000c000000000000046",
-        "r_link_flags": 524475,
-        "r_file_flags": 32,
-        "creation_time": "2020-07-03T22:51:57.966124+00:00",
         "accessed_time": "2020-07-06T04:18:49.803554+00:00",
-        "modified_time": "2020-07-06T04:18:49.576528+00:00",
+        "creation_time": "2020-07-03T22:51:57.966124+00:00",
+        "file_flags": [
+            "FILE_ATTRIBUTE_ARCHIVE"
+        ],
         "file_size": 1490944,
-        "icon_index": 0,
-        "windowstyle": "SW_NORMAL",
+        "guid": "0114020000000000c000000000000046",
+        "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
-        "r_hotkey": 0,
-        "reserved0": 0,
-        "reserved1": 0,
-        "reserved2": 0,
+        "icon_index": 0,
         "link_flags": [
             "HasTargetIDList",
             "HasLinkInfo",
@@ -24,83 +42,65 @@
             "IsUnicode",
             "EnableTargetMetadata"
         ],
-        "file_flags": [
-            "FILE_ATTRIBUTE_ARCHIVE"
-        ]
+        "modified_time": "2020-07-06T04:18:49.576528+00:00",
+        "r_file_flags": 32,
+        "r_hotkey": 0,
+        "r_link_flags": 524475,
+        "reserved0": 0,
+        "reserved1": 0,
+        "reserved2": 0,
+        "windowstyle": "SW_NORMAL"
     },
-    "data": {
-        "relative_path": ".\\AnonymusBrowser.exe",
-        "working_directory": "C:\\AnonymusBrowser-v2.0",
-        "command_line_arguments": "no_ipcheck - username=05551112233 password=123456"
+    "link_info": {
+        "common_network_relative_link_offset": 0,
+        "common_path_suffix": "",
+        "common_path_suffix_offset": 89,
+        "link_info_flags": 1,
+        "link_info_header_size": 28,
+        "link_info_size": 90,
+        "local_base_path": "C:\\AnonymusBrowser-v2.0\\AnonymusBrowser.exe",
+        "local_base_path_offset": 45,
+        "location": "Local",
+        "location_info": {
+            "drive_serial_number": "0xd215cbdb",
+            "drive_type": "DRIVE_FIXED",
+            "r_drive_type": 3,
+            "volume_id_size": 17,
+            "volume_label": "",
+            "volume_label_offset": 16
+        },
+        "volume_id_offset": 28
     },
     "target": {
-        "size": 279,
+        "index": 78,
         "items": [
             {
                 "class": "Root Folder",
-                "sort_index": "My Computer",
-                "guid": "e04fd020ea3a6910a2d808002b30309d"
+                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "sort_index": "My Computer"
             },
             {
                 "class": "Volume Item",
-                "flags": "0xf",
-                "data": "C:\\"
+                "data": "C:\\",
+                "flags": "0xf"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "1997-10-07T10:07:12+00:00",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "1997-10-07T10:07:12+00:00",
                 "primary_name": "ANONYM~1.0"
             },
             {
                 "class": "File entry",
-                "flags": "Is file",
-                "file_size": 1490944,
-                "modification_time": "1997-02-25T10:07:12+00:00",
                 "file_attribute_flags": 32,
+                "file_size": 1490944,
+                "flags": "Is file",
+                "modification_time": "1997-02-25T10:07:12+00:00",
                 "primary_name": "ANONYM~1.EXE"
             }
         ],
-        "index": 78
-    },
-    "link_info": {
-        "link_info_size": 90,
-        "link_info_header_size": 28,
-        "link_info_flags": 1,
-        "volume_id_offset": 28,
-        "local_base_path_offset": 45,
-        "common_network_relative_link_offset": 0,
-        "common_path_suffix_offset": 89,
-        "local_base_path": "C:\\AnonymusBrowser-v2.0\\AnonymusBrowser.exe",
-        "common_path_suffix": "",
-        "location": "Local",
-        "location_info": {
-            "volume_id_size": 17,
-            "r_drive_type": 3,
-            "drive_serial_number": "0xd215cbdb",
-            "volume_label_offset": 16,
-            "drive_type": "DRIVE_FIXED",
-            "volume_label": ""
-        }
-    },
-    "extra": {
-        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "size": 96,
-            "length": 88,
-            "version": 0,
-            "machine_identifier": "desktop-73cl5qt",
-            "droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
-            "droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
-            "birth_droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
-            "birth_droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e"
-        },
-        "METADATA_PROPERTIES_BLOCK": {
-            "size": 484,
-            "storage_size": 97,
-            "version": "0x53505331",
-            "format_id": "ed30bdda43008947a7f8d013a4736622"
-        }
+        "size": 279
     }
 }

--- a/tests/json/lnk_success.lnk.json
+++ b/tests/json/lnk_success.lnk.json
@@ -6,17 +6,17 @@
     },
     "extra": {
         "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "birth_droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
-            "birth_droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
-            "droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
-            "droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
+            "birth_droid_file_identifier": "06CC9568-BF32-11EA-ABA1-0000FAAD700E",
+            "birth_droid_volume_identifier": "2EBF7902-EDAA-43D6-A855-0000F7BABFF2",
+            "droid_file_identifier": "06CC9568-BF32-11EA-ABA1-0000FAAD700E",
+            "droid_volume_identifier": "2EBF7902-EDAA-43D6-A855-0000F7BABFF2",
             "length": 88,
             "machine_identifier": "desktop-73cl5qt",
             "size": 96,
             "version": 0
         },
         "METADATA_PROPERTIES_BLOCK": {
-            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "format_id": "DABD30ED-0043-4789-A7F8-0000F4736622",
             "size": 484,
             "storage_size": 97,
             "version": "0x53505331"
@@ -29,7 +29,7 @@
             "FILE_ATTRIBUTE_ARCHIVE"
         ],
         "file_size": 1490944,
-        "guid": "0114020000000000c000000000000046",
+        "guid": "00021401-0000-0000-C000-000000000046",
         "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
         "icon_index": 0,
@@ -76,7 +76,7 @@
         "items": [
             {
                 "class": "Root Folder",
-                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "guid": "20D04FE0-3AEA-1069-A2D8-00002B30309D",
                 "sort_index": "My Computer"
             },
             {

--- a/tests/json/lnk_success2.lnk.json
+++ b/tests/json/lnk_success2.lnk.json
@@ -6,17 +6,17 @@
     },
     "extra": {
         "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "birth_droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
-            "birth_droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
-            "droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
-            "droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
+            "birth_droid_file_identifier": "06CC9568-BF32-11EA-ABA1-0000FAAD700E",
+            "birth_droid_volume_identifier": "2EBF7902-EDAA-43D6-A855-0000F7BABFF2",
+            "droid_file_identifier": "06CC9568-BF32-11EA-ABA1-0000FAAD700E",
+            "droid_volume_identifier": "2EBF7902-EDAA-43D6-A855-0000F7BABFF2",
             "length": 88,
             "machine_identifier": "desktop-73cl5qt",
             "size": 96,
             "version": 0
         },
         "METADATA_PROPERTIES_BLOCK": {
-            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "format_id": "DABD30ED-0043-4789-A7F8-0000F4736622",
             "size": 484,
             "storage_size": 97,
             "version": "0x53505331"
@@ -29,7 +29,7 @@
             "FILE_ATTRIBUTE_ARCHIVE"
         ],
         "file_size": 1490944,
-        "guid": "0114020000000000c000000000000046",
+        "guid": "00021401-0000-0000-C000-000000000046",
         "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
         "icon_index": 0,
@@ -76,7 +76,7 @@
         "items": [
             {
                 "class": "Root Folder",
-                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "guid": "20D04FE0-3AEA-1069-A2D8-00002B30309D",
                 "sort_index": "My Computer"
             },
             {

--- a/tests/json/lnk_success2.lnk.json
+++ b/tests/json/lnk_success2.lnk.json
@@ -1,20 +1,38 @@
 {
+    "data": {
+        "command_line_arguments": "no_ipcheck no_resize",
+        "relative_path": ".\\AnonymusBrowser.exe",
+        "working_directory": "C:\\AnonymusBrowser-v2.0"
+    },
+    "extra": {
+        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
+            "birth_droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
+            "birth_droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
+            "droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
+            "droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
+            "length": 88,
+            "machine_identifier": "desktop-73cl5qt",
+            "size": 96,
+            "version": 0
+        },
+        "METADATA_PROPERTIES_BLOCK": {
+            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "size": 484,
+            "storage_size": 97,
+            "version": "0x53505331"
+        }
+    },
     "header": {
-        "header_size": 76,
-        "guid": "0114020000000000c000000000000046",
-        "r_link_flags": 524475,
-        "r_file_flags": 32,
-        "creation_time": "2020-07-03T22:51:57.966124+00:00",
         "accessed_time": "2020-07-06T04:18:49.803554+00:00",
-        "modified_time": "2020-07-06T04:18:49.576528+00:00",
+        "creation_time": "2020-07-03T22:51:57.966124+00:00",
+        "file_flags": [
+            "FILE_ATTRIBUTE_ARCHIVE"
+        ],
         "file_size": 1490944,
-        "icon_index": 0,
-        "windowstyle": "SW_NORMAL",
+        "guid": "0114020000000000c000000000000046",
+        "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
-        "r_hotkey": 0,
-        "reserved0": 0,
-        "reserved1": 0,
-        "reserved2": 0,
+        "icon_index": 0,
         "link_flags": [
             "HasTargetIDList",
             "HasLinkInfo",
@@ -24,83 +42,65 @@
             "IsUnicode",
             "EnableTargetMetadata"
         ],
-        "file_flags": [
-            "FILE_ATTRIBUTE_ARCHIVE"
-        ]
+        "modified_time": "2020-07-06T04:18:49.576528+00:00",
+        "r_file_flags": 32,
+        "r_hotkey": 0,
+        "r_link_flags": 524475,
+        "reserved0": 0,
+        "reserved1": 0,
+        "reserved2": 0,
+        "windowstyle": "SW_NORMAL"
     },
-    "data": {
-        "relative_path": ".\\AnonymusBrowser.exe",
-        "working_directory": "C:\\AnonymusBrowser-v2.0",
-        "command_line_arguments": "no_ipcheck no_resize"
+    "link_info": {
+        "common_network_relative_link_offset": 0,
+        "common_path_suffix": "",
+        "common_path_suffix_offset": 89,
+        "link_info_flags": 1,
+        "link_info_header_size": 28,
+        "link_info_size": 90,
+        "local_base_path": "C:\\AnonymusBrowser-v2.0\\AnonymusBrowser.exe",
+        "local_base_path_offset": 45,
+        "location": "Local",
+        "location_info": {
+            "drive_serial_number": "0xd215cbdb",
+            "drive_type": "DRIVE_FIXED",
+            "r_drive_type": 3,
+            "volume_id_size": 17,
+            "volume_label": "",
+            "volume_label_offset": 16
+        },
+        "volume_id_offset": 28
     },
     "target": {
-        "size": 279,
+        "index": 78,
         "items": [
             {
                 "class": "Root Folder",
-                "sort_index": "My Computer",
-                "guid": "e04fd020ea3a6910a2d808002b30309d"
+                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "sort_index": "My Computer"
             },
             {
                 "class": "Volume Item",
-                "flags": "0xf",
-                "data": "C:\\"
+                "data": "C:\\",
+                "flags": "0xf"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "1997-10-07T10:07:12+00:00",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "1997-10-07T10:07:12+00:00",
                 "primary_name": "ANONYM~1.0"
             },
             {
                 "class": "File entry",
-                "flags": "Is file",
-                "file_size": 1490944,
-                "modification_time": "1997-02-25T10:07:12+00:00",
                 "file_attribute_flags": 32,
+                "file_size": 1490944,
+                "flags": "Is file",
+                "modification_time": "1997-02-25T10:07:12+00:00",
                 "primary_name": "ANONYM~1.EXE"
             }
         ],
-        "index": 78
-    },
-    "link_info": {
-        "link_info_size": 90,
-        "link_info_header_size": 28,
-        "link_info_flags": 1,
-        "volume_id_offset": 28,
-        "local_base_path_offset": 45,
-        "common_network_relative_link_offset": 0,
-        "common_path_suffix_offset": 89,
-        "local_base_path": "C:\\AnonymusBrowser-v2.0\\AnonymusBrowser.exe",
-        "common_path_suffix": "",
-        "location": "Local",
-        "location_info": {
-            "volume_id_size": 17,
-            "r_drive_type": 3,
-            "drive_serial_number": "0xd215cbdb",
-            "volume_label_offset": 16,
-            "drive_type": "DRIVE_FIXED",
-            "volume_label": ""
-        }
-    },
-    "extra": {
-        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "size": 96,
-            "length": 88,
-            "version": 0,
-            "machine_identifier": "desktop-73cl5qt",
-            "droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
-            "droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
-            "birth_droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
-            "birth_droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e"
-        },
-        "METADATA_PROPERTIES_BLOCK": {
-            "size": 484,
-            "storage_size": 97,
-            "version": "0x53505331",
-            "format_id": "ed30bdda43008947a7f8d013a4736622"
-        }
+        "size": 279
     }
 }

--- a/tests/json/lnk_success3.lnk.json
+++ b/tests/json/lnk_success3.lnk.json
@@ -5,22 +5,22 @@
     },
     "extra": {
         "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "birth_droid_file_identifier": "06eac9a3847aea11affc9bbabfbed054",
-            "birth_droid_volume_identifier": "96c86bde486d594588f3cb1f7258f3bb",
-            "droid_file_identifier": "06eac9a3847aea11affc9bbabfbed054",
-            "droid_volume_identifier": "96c86bde486d594588f3cb1f7258f3bb",
+            "birth_droid_file_identifier": "A3C9EA06-7A84-11EA-AFFC-0000BFBED054",
+            "birth_droid_volume_identifier": "DE6BC896-6D48-4559-88F3-0000FB5FF3BB",
+            "droid_file_identifier": "A3C9EA06-7A84-11EA-AFFC-0000BFBED054",
+            "droid_volume_identifier": "DE6BC896-6D48-4559-88F3-0000FB5FF3BB",
             "length": 88,
             "machine_identifier": "officepc01",
             "size": 96,
             "version": 0
         },
         "KNOWN_FOLDER_LOCATION_BLOCK": {
-            "known_folder_id": "ef405a7cfba0fc4b874ac0f2e0b9fa8e",
+            "known_folder_id": "7C5A40EF-A0FB-4BFC-874A-0000E0FBFA8E",
             "offset": 193,
             "size": 28
         },
         "METADATA_PROPERTIES_BLOCK": {
-            "format_id": "e28a5846bc4c3843bbfc139326986dce",
+            "format_id": "46588AE2-4CBC-4338-BBFC-0000379B6DCE",
             "size": 153,
             "storage_size": 141,
             "version": "0x53505331"
@@ -38,7 +38,7 @@
             "FILE_ATTRIBUTE_ARCHIVE"
         ],
         "file_size": 558080,
-        "guid": "0114020000000000c000000000000046",
+        "guid": "00021401-0000-0000-C000-000000000046",
         "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
         "icon_index": 0,
@@ -83,7 +83,7 @@
         "items": [
             {
                 "class": "Root Folder",
-                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "guid": "20D04FE0-3AEA-1069-A2D8-00002B30309D",
                 "sort_index": "My Computer"
             },
             {

--- a/tests/json/lnk_success3.lnk.json
+++ b/tests/json/lnk_success3.lnk.json
@@ -1,20 +1,47 @@
 {
+    "data": {
+        "relative_path": "..\\..\\..\\Program Files (x86)\\HDZB_USBKEY_NEW1G\\HDZB_USBKEY_NEW1G.exe",
+        "working_directory": "C:\\Program Files (x86)\\Mozilla Firefox"
+    },
+    "extra": {
+        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
+            "birth_droid_file_identifier": "06eac9a3847aea11affc9bbabfbed054",
+            "birth_droid_volume_identifier": "96c86bde486d594588f3cb1f7258f3bb",
+            "droid_file_identifier": "06eac9a3847aea11affc9bbabfbed054",
+            "droid_volume_identifier": "96c86bde486d594588f3cb1f7258f3bb",
+            "length": 88,
+            "machine_identifier": "officepc01",
+            "size": 96,
+            "version": 0
+        },
+        "KNOWN_FOLDER_LOCATION_BLOCK": {
+            "known_folder_id": "ef405a7cfba0fc4b874ac0f2e0b9fa8e",
+            "offset": 193,
+            "size": 28
+        },
+        "METADATA_PROPERTIES_BLOCK": {
+            "format_id": "e28a5846bc4c3843bbfc139326986dce",
+            "size": 153,
+            "storage_size": 141,
+            "version": "0x53505331"
+        },
+        "SPECIAL_FOLDER_LOCATION_BLOCK": {
+            "offset": 193,
+            "size": 16,
+            "special_folder_id": 42
+        }
+    },
     "header": {
-        "header_size": 76,
-        "guid": "0114020000000000c000000000000046",
-        "r_link_flags": 155,
-        "r_file_flags": 32,
-        "creation_time": "2020-08-05T06:33:04+00:00",
         "accessed_time": "2020-08-23T21:02:13.755200+00:00",
-        "modified_time": "2020-08-05T06:33:04+00:00",
+        "creation_time": "2020-08-05T06:33:04+00:00",
+        "file_flags": [
+            "FILE_ATTRIBUTE_ARCHIVE"
+        ],
         "file_size": 558080,
-        "icon_index": 0,
-        "windowstyle": "SW_NORMAL",
+        "guid": "0114020000000000c000000000000046",
+        "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
-        "r_hotkey": 0,
-        "reserved0": 0,
-        "reserved1": 0,
-        "reserved2": 0,
+        "icon_index": 0,
         "link_flags": [
             "HasTargetIDList",
             "HasLinkInfo",
@@ -22,100 +49,73 @@
             "HasWorkingDir",
             "IsUnicode"
         ],
-        "file_flags": [
-            "FILE_ATTRIBUTE_ARCHIVE"
-        ]
+        "modified_time": "2020-08-05T06:33:04+00:00",
+        "r_file_flags": 32,
+        "r_hotkey": 0,
+        "r_link_flags": 155,
+        "reserved0": 0,
+        "reserved1": 0,
+        "reserved2": 0,
+        "windowstyle": "SW_NORMAL"
     },
-    "data": {
-        "relative_path": "..\\..\\..\\Program Files (x86)\\HDZB_USBKEY_NEW1G\\HDZB_USBKEY_NEW1G.exe",
-        "working_directory": "C:\\Program Files (x86)\\Mozilla Firefox"
+    "link_info": {
+        "common_network_relative_link_offset": 0,
+        "common_path_suffix": "",
+        "common_path_suffix_offset": 115,
+        "link_info_flags": 1,
+        "link_info_header_size": 28,
+        "link_info_size": 116,
+        "local_base_path": "C:\\Program Files (x86)\\HDZB_USBKEY_NEW1G\\HDZB_USBKEY_NEW1G.exe",
+        "local_base_path_offset": 52,
+        "location": "Local",
+        "location_info": {
+            "drive_serial_number": "0xa4685e10",
+            "drive_type": "DRIVE_FIXED",
+            "r_drive_type": 3,
+            "volume_id_size": 24,
+            "volume_label": "Windows",
+            "volume_label_offset": 16
+        },
+        "volume_id_offset": 28
     },
     "target": {
-        "size": 415,
+        "index": 78,
         "items": [
             {
                 "class": "Root Folder",
-                "sort_index": "My Computer",
-                "guid": "e04fd020ea3a6910a2d808002b30309d"
+                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "sort_index": "My Computer"
             },
             {
                 "class": "Volume Item",
-                "flags": "0xf",
-                "data": "C:\\"
+                "data": "C:\\",
+                "flags": "0xf"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "2064-02-07T10:08:46+00:00",
                 "file_attribute_flags": 17,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "2064-02-07T10:08:46+00:00",
                 "primary_name": "PROGRA~2"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "2064-02-08T10:08:46+00:00",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "2064-02-08T10:08:46+00:00",
                 "primary_name": "HDZB_U~1"
             },
             {
                 "class": "File entry",
-                "flags": "Is file",
-                "file_size": 558080,
-                "modification_time": "2006-01-02T10:08:10+00:00",
                 "file_attribute_flags": 32,
+                "file_size": 558080,
+                "flags": "Is file",
+                "modification_time": "2006-01-02T10:08:10+00:00",
                 "primary_name": "HDZB_U~1.EXE"
             }
         ],
-        "index": 78
-    },
-    "link_info": {
-        "link_info_size": 116,
-        "link_info_header_size": 28,
-        "link_info_flags": 1,
-        "volume_id_offset": 28,
-        "local_base_path_offset": 52,
-        "common_network_relative_link_offset": 0,
-        "common_path_suffix_offset": 115,
-        "local_base_path": "C:\\Program Files (x86)\\HDZB_USBKEY_NEW1G\\HDZB_USBKEY_NEW1G.exe",
-        "common_path_suffix": "",
-        "location": "Local",
-        "location_info": {
-            "volume_id_size": 24,
-            "r_drive_type": 3,
-            "drive_serial_number": "0xa4685e10",
-            "volume_label_offset": 16,
-            "drive_type": "DRIVE_FIXED",
-            "volume_label": "Windows"
-        }
-    },
-    "extra": {
-        "SPECIAL_FOLDER_LOCATION_BLOCK": {
-            "size": 16,
-            "special_folder_id": 42,
-            "offset": 193
-        },
-        "KNOWN_FOLDER_LOCATION_BLOCK": {
-            "size": 28,
-            "known_folder_id": "ef405a7cfba0fc4b874ac0f2e0b9fa8e",
-            "offset": 193
-        },
-        "METADATA_PROPERTIES_BLOCK": {
-            "size": 153,
-            "storage_size": 141,
-            "version": "0x53505331",
-            "format_id": "e28a5846bc4c3843bbfc139326986dce"
-        },
-        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "size": 96,
-            "length": 88,
-            "version": 0,
-            "machine_identifier": "officepc01",
-            "droid_volume_identifier": "96c86bde486d594588f3cb1f7258f3bb",
-            "droid_file_identifier": "06eac9a3847aea11affc9bbabfbed054",
-            "birth_droid_volume_identifier": "96c86bde486d594588f3cb1f7258f3bb",
-            "birth_droid_file_identifier": "06eac9a3847aea11affc9bbabfbed054"
-        }
+        "size": 415
     }
 }

--- a/tests/json/lnk_success4.lnk.json
+++ b/tests/json/lnk_success4.lnk.json
@@ -1,20 +1,38 @@
 {
+    "data": {
+        "command_line_arguments": "no_ipcheck",
+        "relative_path": ".\\AnonymusBrowser.exe",
+        "working_directory": "C:\\AnonymusBrowser-v2.0"
+    },
+    "extra": {
+        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
+            "birth_droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
+            "birth_droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
+            "droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
+            "droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
+            "length": 88,
+            "machine_identifier": "desktop-73cl5qt",
+            "size": 96,
+            "version": 0
+        },
+        "METADATA_PROPERTIES_BLOCK": {
+            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "size": 484,
+            "storage_size": 97,
+            "version": "0x53505331"
+        }
+    },
     "header": {
-        "header_size": 76,
-        "guid": "0114020000000000c000000000000046",
-        "r_link_flags": 524475,
-        "r_file_flags": 32,
-        "creation_time": "2020-07-03T22:51:57.966124+00:00",
         "accessed_time": "2020-07-06T04:18:49.803554+00:00",
-        "modified_time": "2020-07-06T04:18:49.576528+00:00",
+        "creation_time": "2020-07-03T22:51:57.966124+00:00",
+        "file_flags": [
+            "FILE_ATTRIBUTE_ARCHIVE"
+        ],
         "file_size": 1490944,
-        "icon_index": 0,
-        "windowstyle": "SW_NORMAL",
+        "guid": "0114020000000000c000000000000046",
+        "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
-        "r_hotkey": 0,
-        "reserved0": 0,
-        "reserved1": 0,
-        "reserved2": 0,
+        "icon_index": 0,
         "link_flags": [
             "HasTargetIDList",
             "HasLinkInfo",
@@ -24,83 +42,65 @@
             "IsUnicode",
             "EnableTargetMetadata"
         ],
-        "file_flags": [
-            "FILE_ATTRIBUTE_ARCHIVE"
-        ]
+        "modified_time": "2020-07-06T04:18:49.576528+00:00",
+        "r_file_flags": 32,
+        "r_hotkey": 0,
+        "r_link_flags": 524475,
+        "reserved0": 0,
+        "reserved1": 0,
+        "reserved2": 0,
+        "windowstyle": "SW_NORMAL"
     },
-    "data": {
-        "relative_path": ".\\AnonymusBrowser.exe",
-        "working_directory": "C:\\AnonymusBrowser-v2.0",
-        "command_line_arguments": "no_ipcheck"
+    "link_info": {
+        "common_network_relative_link_offset": 0,
+        "common_path_suffix": "",
+        "common_path_suffix_offset": 89,
+        "link_info_flags": 1,
+        "link_info_header_size": 28,
+        "link_info_size": 90,
+        "local_base_path": "C:\\AnonymusBrowser-v2.0\\AnonymusBrowser.exe",
+        "local_base_path_offset": 45,
+        "location": "Local",
+        "location_info": {
+            "drive_serial_number": "0xd215cbdb",
+            "drive_type": "DRIVE_FIXED",
+            "r_drive_type": 3,
+            "volume_id_size": 17,
+            "volume_label": "",
+            "volume_label_offset": 16
+        },
+        "volume_id_offset": 28
     },
     "target": {
-        "size": 279,
+        "index": 78,
         "items": [
             {
                 "class": "Root Folder",
-                "sort_index": "My Computer",
-                "guid": "e04fd020ea3a6910a2d808002b30309d"
+                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "sort_index": "My Computer"
             },
             {
                 "class": "Volume Item",
-                "flags": "0xf",
-                "data": "C:\\"
+                "data": "C:\\",
+                "flags": "0xf"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "1997-10-07T10:07:12+00:00",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "1997-10-07T10:07:12+00:00",
                 "primary_name": "ANONYM~1.0"
             },
             {
                 "class": "File entry",
-                "flags": "Is file",
-                "file_size": 1490944,
-                "modification_time": "1997-02-25T10:07:12+00:00",
                 "file_attribute_flags": 32,
+                "file_size": 1490944,
+                "flags": "Is file",
+                "modification_time": "1997-02-25T10:07:12+00:00",
                 "primary_name": "ANONYM~1.EXE"
             }
         ],
-        "index": 78
-    },
-    "link_info": {
-        "link_info_size": 90,
-        "link_info_header_size": 28,
-        "link_info_flags": 1,
-        "volume_id_offset": 28,
-        "local_base_path_offset": 45,
-        "common_network_relative_link_offset": 0,
-        "common_path_suffix_offset": 89,
-        "local_base_path": "C:\\AnonymusBrowser-v2.0\\AnonymusBrowser.exe",
-        "common_path_suffix": "",
-        "location": "Local",
-        "location_info": {
-            "volume_id_size": 17,
-            "r_drive_type": 3,
-            "drive_serial_number": "0xd215cbdb",
-            "volume_label_offset": 16,
-            "drive_type": "DRIVE_FIXED",
-            "volume_label": ""
-        }
-    },
-    "extra": {
-        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "size": 96,
-            "length": 88,
-            "version": 0,
-            "machine_identifier": "desktop-73cl5qt",
-            "droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
-            "droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
-            "birth_droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
-            "birth_droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e"
-        },
-        "METADATA_PROPERTIES_BLOCK": {
-            "size": 484,
-            "storage_size": 97,
-            "version": "0x53505331",
-            "format_id": "ed30bdda43008947a7f8d013a4736622"
-        }
+        "size": 279
     }
 }

--- a/tests/json/lnk_success4.lnk.json
+++ b/tests/json/lnk_success4.lnk.json
@@ -6,17 +6,17 @@
     },
     "extra": {
         "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "birth_droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
-            "birth_droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
-            "droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
-            "droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
+            "birth_droid_file_identifier": "06CC9568-BF32-11EA-ABA1-0000FAAD700E",
+            "birth_droid_volume_identifier": "2EBF7902-EDAA-43D6-A855-0000F7BABFF2",
+            "droid_file_identifier": "06CC9568-BF32-11EA-ABA1-0000FAAD700E",
+            "droid_volume_identifier": "2EBF7902-EDAA-43D6-A855-0000F7BABFF2",
             "length": 88,
             "machine_identifier": "desktop-73cl5qt",
             "size": 96,
             "version": 0
         },
         "METADATA_PROPERTIES_BLOCK": {
-            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "format_id": "DABD30ED-0043-4789-A7F8-0000F4736622",
             "size": 484,
             "storage_size": 97,
             "version": "0x53505331"
@@ -29,7 +29,7 @@
             "FILE_ATTRIBUTE_ARCHIVE"
         ],
         "file_size": 1490944,
-        "guid": "0114020000000000c000000000000046",
+        "guid": "00021401-0000-0000-C000-000000000046",
         "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
         "icon_index": 0,
@@ -76,7 +76,7 @@
         "items": [
             {
                 "class": "Root Folder",
-                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "guid": "20D04FE0-3AEA-1069-A2D8-00002B30309D",
                 "sort_index": "My Computer"
             },
             {

--- a/tests/json/lnk_success5.lnk.json
+++ b/tests/json/lnk_success5.lnk.json
@@ -6,17 +6,17 @@
     },
     "extra": {
         "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "birth_droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
-            "birth_droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
-            "droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
-            "droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
+            "birth_droid_file_identifier": "06CC9568-BF32-11EA-ABA1-0000FAAD700E",
+            "birth_droid_volume_identifier": "2EBF7902-EDAA-43D6-A855-0000F7BABFF2",
+            "droid_file_identifier": "06CC9568-BF32-11EA-ABA1-0000FAAD700E",
+            "droid_volume_identifier": "2EBF7902-EDAA-43D6-A855-0000F7BABFF2",
             "length": 88,
             "machine_identifier": "desktop-73cl5qt",
             "size": 96,
             "version": 0
         },
         "METADATA_PROPERTIES_BLOCK": {
-            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "format_id": "DABD30ED-0043-4789-A7F8-0000F4736622",
             "size": 484,
             "storage_size": 97,
             "version": "0x53505331"
@@ -29,7 +29,7 @@
             "FILE_ATTRIBUTE_ARCHIVE"
         ],
         "file_size": 1490944,
-        "guid": "0114020000000000c000000000000046",
+        "guid": "00021401-0000-0000-C000-000000000046",
         "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
         "icon_index": 0,
@@ -76,7 +76,7 @@
         "items": [
             {
                 "class": "Root Folder",
-                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "guid": "20D04FE0-3AEA-1069-A2D8-00002B30309D",
                 "sort_index": "My Computer"
             },
             {

--- a/tests/json/lnk_success5.lnk.json
+++ b/tests/json/lnk_success5.lnk.json
@@ -1,20 +1,38 @@
 {
+    "data": {
+        "command_line_arguments": "no_resize",
+        "relative_path": ".\\AnonymusBrowser.exe",
+        "working_directory": "C:\\AnonymusBrowser-v2.0"
+    },
+    "extra": {
+        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
+            "birth_droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
+            "birth_droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
+            "droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
+            "droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
+            "length": 88,
+            "machine_identifier": "desktop-73cl5qt",
+            "size": 96,
+            "version": 0
+        },
+        "METADATA_PROPERTIES_BLOCK": {
+            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "size": 484,
+            "storage_size": 97,
+            "version": "0x53505331"
+        }
+    },
     "header": {
-        "header_size": 76,
-        "guid": "0114020000000000c000000000000046",
-        "r_link_flags": 524475,
-        "r_file_flags": 32,
-        "creation_time": "2020-07-03T22:51:57.966124+00:00",
         "accessed_time": "2020-07-06T04:18:49.803554+00:00",
-        "modified_time": "2020-07-06T04:18:49.576528+00:00",
+        "creation_time": "2020-07-03T22:51:57.966124+00:00",
+        "file_flags": [
+            "FILE_ATTRIBUTE_ARCHIVE"
+        ],
         "file_size": 1490944,
-        "icon_index": 0,
-        "windowstyle": "SW_NORMAL",
+        "guid": "0114020000000000c000000000000046",
+        "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
-        "r_hotkey": 0,
-        "reserved0": 0,
-        "reserved1": 0,
-        "reserved2": 0,
+        "icon_index": 0,
         "link_flags": [
             "HasTargetIDList",
             "HasLinkInfo",
@@ -24,83 +42,65 @@
             "IsUnicode",
             "EnableTargetMetadata"
         ],
-        "file_flags": [
-            "FILE_ATTRIBUTE_ARCHIVE"
-        ]
+        "modified_time": "2020-07-06T04:18:49.576528+00:00",
+        "r_file_flags": 32,
+        "r_hotkey": 0,
+        "r_link_flags": 524475,
+        "reserved0": 0,
+        "reserved1": 0,
+        "reserved2": 0,
+        "windowstyle": "SW_NORMAL"
     },
-    "data": {
-        "relative_path": ".\\AnonymusBrowser.exe",
-        "working_directory": "C:\\AnonymusBrowser-v2.0",
-        "command_line_arguments": "no_resize"
+    "link_info": {
+        "common_network_relative_link_offset": 0,
+        "common_path_suffix": "",
+        "common_path_suffix_offset": 89,
+        "link_info_flags": 1,
+        "link_info_header_size": 28,
+        "link_info_size": 90,
+        "local_base_path": "C:\\AnonymusBrowser-v2.0\\AnonymusBrowser.exe",
+        "local_base_path_offset": 45,
+        "location": "Local",
+        "location_info": {
+            "drive_serial_number": "0xd215cbdb",
+            "drive_type": "DRIVE_FIXED",
+            "r_drive_type": 3,
+            "volume_id_size": 17,
+            "volume_label": "",
+            "volume_label_offset": 16
+        },
+        "volume_id_offset": 28
     },
     "target": {
-        "size": 279,
+        "index": 78,
         "items": [
             {
                 "class": "Root Folder",
-                "sort_index": "My Computer",
-                "guid": "e04fd020ea3a6910a2d808002b30309d"
+                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "sort_index": "My Computer"
             },
             {
                 "class": "Volume Item",
-                "flags": "0xf",
-                "data": "C:\\"
+                "data": "C:\\",
+                "flags": "0xf"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "1997-10-07T10:07:12+00:00",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "1997-10-07T10:07:12+00:00",
                 "primary_name": "ANONYM~1.0"
             },
             {
                 "class": "File entry",
-                "flags": "Is file",
-                "file_size": 1490944,
-                "modification_time": "1997-02-25T10:07:12+00:00",
                 "file_attribute_flags": 32,
+                "file_size": 1490944,
+                "flags": "Is file",
+                "modification_time": "1997-02-25T10:07:12+00:00",
                 "primary_name": "ANONYM~1.EXE"
             }
         ],
-        "index": 78
-    },
-    "link_info": {
-        "link_info_size": 90,
-        "link_info_header_size": 28,
-        "link_info_flags": 1,
-        "volume_id_offset": 28,
-        "local_base_path_offset": 45,
-        "common_network_relative_link_offset": 0,
-        "common_path_suffix_offset": 89,
-        "local_base_path": "C:\\AnonymusBrowser-v2.0\\AnonymusBrowser.exe",
-        "common_path_suffix": "",
-        "location": "Local",
-        "location_info": {
-            "volume_id_size": 17,
-            "r_drive_type": 3,
-            "drive_serial_number": "0xd215cbdb",
-            "volume_label_offset": 16,
-            "drive_type": "DRIVE_FIXED",
-            "volume_label": ""
-        }
-    },
-    "extra": {
-        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "size": 96,
-            "length": 88,
-            "version": 0,
-            "machine_identifier": "desktop-73cl5qt",
-            "droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
-            "droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
-            "birth_droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
-            "birth_droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e"
-        },
-        "METADATA_PROPERTIES_BLOCK": {
-            "size": 484,
-            "storage_size": 97,
-            "version": "0x53505331",
-            "format_id": "ed30bdda43008947a7f8d013a4736622"
-        }
+        "size": 279
     }
 }

--- a/tests/json/lnk_success6.lnk.json
+++ b/tests/json/lnk_success6.lnk.json
@@ -6,10 +6,10 @@
     },
     "extra": {
         "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "birth_droid_file_identifier": "d3d3853cc9e5ea11abb04c72b91387bc",
-            "birth_droid_volume_identifier": "2a3dc1e9b0b69f4396b8480f5acbca8c",
-            "droid_file_identifier": "d3d3853cc9e5ea11abb04c72b91387bc",
-            "droid_volume_identifier": "2a3dc1e9b0b69f4396b8480f5acbca8c",
+            "birth_droid_file_identifier": "3C85D3D3-E5C9-11EA-ABB0-0000FD7387BC",
+            "birth_droid_volume_identifier": "E9C13D2A-B6B0-439F-96B8-00005ACFCA8C",
+            "droid_file_identifier": "3C85D3D3-E5C9-11EA-ABB0-0000FD7387BC",
+            "droid_volume_identifier": "E9C13D2A-B6B0-439F-96B8-00005ACFCA8C",
             "length": 88,
             "machine_identifier": "w-51511",
             "size": 96,
@@ -21,12 +21,12 @@
             "target_unicode": "%"
         },
         "KNOWN_FOLDER_LOCATION_BLOCK": {
-            "known_folder_id": "774ec11ae7025d4eb7442eb1ae5198b7",
+            "known_folder_id": "1AC14E77-02E7-4E5D-B744-0000AEF198B7",
             "offset": 213,
             "size": 28
         },
         "METADATA_PROPERTIES_BLOCK": {
-            "format_id": "e28a5846bc4c3843bbfc139326986dce",
+            "format_id": "46588AE2-4CBC-4338-BBFC-0000379B6DCE",
             "size": 153,
             "storage_size": 141,
             "version": "0x53505331"
@@ -44,7 +44,7 @@
             "FILE_ATTRIBUTE_ARCHIVE"
         ],
         "file_size": 302592,
-        "guid": "0114020000000000c000000000000046",
+        "guid": "00021401-0000-0000-C000-000000000046",
         "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
         "icon_index": 9,
@@ -91,7 +91,7 @@
         "items": [
             {
                 "class": "Root Folder",
-                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "guid": "20D04FE0-3AEA-1069-A2D8-00002B30309D",
                 "sort_index": "My Computer"
             },
             {

--- a/tests/json/lnk_success6.lnk.json
+++ b/tests/json/lnk_success6.lnk.json
@@ -1,20 +1,53 @@
 {
+    "data": {
+        "command_line_arguments": "/c start _ & _\\DeviceManager.exe & exit",
+        "icon_location": "shell32.dll",
+        "working_directory": "B:\\"
+    },
+    "extra": {
+        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
+            "birth_droid_file_identifier": "d3d3853cc9e5ea11abb04c72b91387bc",
+            "birth_droid_volume_identifier": "2a3dc1e9b0b69f4396b8480f5acbca8c",
+            "droid_file_identifier": "d3d3853cc9e5ea11abb04c72b91387bc",
+            "droid_volume_identifier": "2a3dc1e9b0b69f4396b8480f5acbca8c",
+            "length": 88,
+            "machine_identifier": "w-51511",
+            "size": 96,
+            "version": 0
+        },
+        "ENVIRONMENTAL_VARIABLES_LOCATION_BLOCK": {
+            "size": 788,
+            "target_ansi": "%windir%\\system32\\cmd.exe",
+            "target_unicode": "%"
+        },
+        "KNOWN_FOLDER_LOCATION_BLOCK": {
+            "known_folder_id": "774ec11ae7025d4eb7442eb1ae5198b7",
+            "offset": 213,
+            "size": 28
+        },
+        "METADATA_PROPERTIES_BLOCK": {
+            "format_id": "e28a5846bc4c3843bbfc139326986dce",
+            "size": 153,
+            "storage_size": 141,
+            "version": "0x53505331"
+        },
+        "SPECIAL_FOLDER_LOCATION_BLOCK": {
+            "offset": 213,
+            "size": 16,
+            "special_folder_id": 37
+        }
+    },
     "header": {
-        "header_size": 76,
-        "guid": "0114020000000000c000000000000046",
-        "r_link_flags": 755,
-        "r_file_flags": 32,
-        "creation_time": "2018-12-28T13:06:00.442131+00:00",
         "accessed_time": "2018-12-28T13:06:00.442131+00:00",
-        "modified_time": "2010-11-20T01:17:02+00:00",
+        "creation_time": "2018-12-28T13:06:00.442131+00:00",
+        "file_flags": [
+            "FILE_ATTRIBUTE_ARCHIVE"
+        ],
         "file_size": 302592,
-        "icon_index": 9,
-        "windowstyle": "SW_SHOWMINNOACTIVE",
+        "guid": "0114020000000000c000000000000046",
+        "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
-        "r_hotkey": 0,
-        "reserved0": 0,
-        "reserved1": 0,
-        "reserved2": 0,
+        "icon_index": 9,
         "link_flags": [
             "HasTargetIDList",
             "HasLinkInfo",
@@ -24,106 +57,73 @@
             "IsUnicode",
             "HasExpString"
         ],
-        "file_flags": [
-            "FILE_ATTRIBUTE_ARCHIVE"
-        ]
+        "modified_time": "2010-11-20T01:17:02+00:00",
+        "r_file_flags": 32,
+        "r_hotkey": 0,
+        "r_link_flags": 755,
+        "reserved0": 0,
+        "reserved1": 0,
+        "reserved2": 0,
+        "windowstyle": "SW_SHOWMINNOACTIVE"
     },
-    "data": {
-        "working_directory": "B:\\",
-        "command_line_arguments": "/c start _ & _\\DeviceManager.exe & exit",
-        "icon_location": "shell32.dll"
+    "link_info": {
+        "common_network_relative_link_offset": 0,
+        "common_path_suffix": "",
+        "common_path_suffix_offset": 79,
+        "link_info_flags": 1,
+        "link_info_header_size": 28,
+        "link_info_size": 80,
+        "local_base_path": "C:\\Windows\\System32\\cmd.exe",
+        "local_base_path_offset": 51,
+        "location": "Local",
+        "location_info": {
+            "drive_serial_number": "0x9606dc0f",
+            "drive_type": "DRIVE_FIXED",
+            "r_drive_type": 3,
+            "volume_id_size": 23,
+            "volume_label": "Disk-C",
+            "volume_label_offset": 16
+        },
+        "volume_id_offset": 28
     },
     "target": {
-        "size": 297,
+        "index": 78,
         "items": [
             {
                 "class": "Root Folder",
-                "sort_index": "My Computer",
-                "guid": "e04fd020ea3a6910a2d808002b30309d"
+                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "sort_index": "My Computer"
             },
             {
                 "class": "Volume Item",
-                "flags": "0xf",
-                "data": "C:\\"
+                "data": "C:\\",
+                "flags": "0xf"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "2015-08-02T10:08:40+00:00",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "2015-08-02T10:08:40+00:00",
                 "primary_name": "Windows"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "2008-12-15T10:08:50+00:00",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "2008-12-15T10:08:50+00:00",
                 "primary_name": "System32"
             },
             {
                 "class": "File entry",
-                "flags": "Is file",
-                "file_size": 302592,
-                "modification_time": "1985-01-01T07:43:40+00:00",
                 "file_attribute_flags": 32,
+                "file_size": 302592,
+                "flags": "Is file",
+                "modification_time": "1985-01-01T07:43:40+00:00",
                 "primary_name": "cmd.exe"
             }
         ],
-        "index": 78
-    },
-    "link_info": {
-        "link_info_size": 80,
-        "link_info_header_size": 28,
-        "link_info_flags": 1,
-        "volume_id_offset": 28,
-        "local_base_path_offset": 51,
-        "common_network_relative_link_offset": 0,
-        "common_path_suffix_offset": 79,
-        "local_base_path": "C:\\Windows\\System32\\cmd.exe",
-        "common_path_suffix": "",
-        "location": "Local",
-        "location_info": {
-            "volume_id_size": 23,
-            "r_drive_type": 3,
-            "drive_serial_number": "0x9606dc0f",
-            "volume_label_offset": 16,
-            "drive_type": "DRIVE_FIXED",
-            "volume_label": "Disk-C"
-        }
-    },
-    "extra": {
-        "ENVIRONMENTAL_VARIABLES_LOCATION_BLOCK": {
-            "size": 788,
-            "target_ansi": "%windir%\\system32\\cmd.exe",
-            "target_unicode": "%"
-        },
-        "SPECIAL_FOLDER_LOCATION_BLOCK": {
-            "size": 16,
-            "special_folder_id": 37,
-            "offset": 213
-        },
-        "KNOWN_FOLDER_LOCATION_BLOCK": {
-            "size": 28,
-            "known_folder_id": "774ec11ae7025d4eb7442eb1ae5198b7",
-            "offset": 213
-        },
-        "METADATA_PROPERTIES_BLOCK": {
-            "size": 153,
-            "storage_size": 141,
-            "version": "0x53505331",
-            "format_id": "e28a5846bc4c3843bbfc139326986dce"
-        },
-        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "size": 96,
-            "length": 88,
-            "version": 0,
-            "machine_identifier": "w-51511",
-            "droid_volume_identifier": "2a3dc1e9b0b69f4396b8480f5acbca8c",
-            "droid_file_identifier": "d3d3853cc9e5ea11abb04c72b91387bc",
-            "birth_droid_volume_identifier": "2a3dc1e9b0b69f4396b8480f5acbca8c",
-            "birth_droid_file_identifier": "d3d3853cc9e5ea11abb04c72b91387bc"
-        }
+        "size": 297
     }
 }

--- a/tests/json/lnk_success7.lnk.json
+++ b/tests/json/lnk_success7.lnk.json
@@ -6,17 +6,17 @@
     },
     "extra": {
         "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "birth_droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
-            "birth_droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
-            "droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
-            "droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
+            "birth_droid_file_identifier": "06CC9568-BF32-11EA-ABA1-0000FAAD700E",
+            "birth_droid_volume_identifier": "2EBF7902-EDAA-43D6-A855-0000F7BABFF2",
+            "droid_file_identifier": "06CC9568-BF32-11EA-ABA1-0000FAAD700E",
+            "droid_volume_identifier": "2EBF7902-EDAA-43D6-A855-0000F7BABFF2",
             "length": 88,
             "machine_identifier": "desktop-73cl5qt",
             "size": 96,
             "version": 0
         },
         "METADATA_PROPERTIES_BLOCK": {
-            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "format_id": "DABD30ED-0043-4789-A7F8-0000F4736622",
             "size": 484,
             "storage_size": 97,
             "version": "0x53505331"
@@ -29,7 +29,7 @@
             "FILE_ATTRIBUTE_ARCHIVE"
         ],
         "file_size": 1490944,
-        "guid": "0114020000000000c000000000000046",
+        "guid": "00021401-0000-0000-C000-000000000046",
         "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
         "icon_index": 0,
@@ -76,7 +76,7 @@
         "items": [
             {
                 "class": "Root Folder",
-                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "guid": "20D04FE0-3AEA-1069-A2D8-00002B30309D",
                 "sort_index": "My Computer"
             },
             {

--- a/tests/json/lnk_success7.lnk.json
+++ b/tests/json/lnk_success7.lnk.json
@@ -1,20 +1,38 @@
 {
+    "data": {
+        "command_line_arguments": "no_ipcheck no_resize username=05551112233 password=123456",
+        "relative_path": ".\\AnonymusBrowser.exe",
+        "working_directory": "C:\\AnonymusBrowser-v2.0"
+    },
+    "extra": {
+        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
+            "birth_droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
+            "birth_droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
+            "droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
+            "droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
+            "length": 88,
+            "machine_identifier": "desktop-73cl5qt",
+            "size": 96,
+            "version": 0
+        },
+        "METADATA_PROPERTIES_BLOCK": {
+            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "size": 484,
+            "storage_size": 97,
+            "version": "0x53505331"
+        }
+    },
     "header": {
-        "header_size": 76,
-        "guid": "0114020000000000c000000000000046",
-        "r_link_flags": 524475,
-        "r_file_flags": 32,
-        "creation_time": "2020-07-03T22:51:57.966124+00:00",
         "accessed_time": "2020-07-06T04:18:49.803554+00:00",
-        "modified_time": "2020-07-06T04:18:49.576528+00:00",
+        "creation_time": "2020-07-03T22:51:57.966124+00:00",
+        "file_flags": [
+            "FILE_ATTRIBUTE_ARCHIVE"
+        ],
         "file_size": 1490944,
-        "icon_index": 0,
-        "windowstyle": "SW_NORMAL",
+        "guid": "0114020000000000c000000000000046",
+        "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
-        "r_hotkey": 0,
-        "reserved0": 0,
-        "reserved1": 0,
-        "reserved2": 0,
+        "icon_index": 0,
         "link_flags": [
             "HasTargetIDList",
             "HasLinkInfo",
@@ -24,83 +42,65 @@
             "IsUnicode",
             "EnableTargetMetadata"
         ],
-        "file_flags": [
-            "FILE_ATTRIBUTE_ARCHIVE"
-        ]
+        "modified_time": "2020-07-06T04:18:49.576528+00:00",
+        "r_file_flags": 32,
+        "r_hotkey": 0,
+        "r_link_flags": 524475,
+        "reserved0": 0,
+        "reserved1": 0,
+        "reserved2": 0,
+        "windowstyle": "SW_NORMAL"
     },
-    "data": {
-        "relative_path": ".\\AnonymusBrowser.exe",
-        "working_directory": "C:\\AnonymusBrowser-v2.0",
-        "command_line_arguments": "no_ipcheck no_resize username=05551112233 password=123456"
+    "link_info": {
+        "common_network_relative_link_offset": 0,
+        "common_path_suffix": "",
+        "common_path_suffix_offset": 89,
+        "link_info_flags": 1,
+        "link_info_header_size": 28,
+        "link_info_size": 90,
+        "local_base_path": "C:\\AnonymusBrowser-v2.0\\AnonymusBrowser.exe",
+        "local_base_path_offset": 45,
+        "location": "Local",
+        "location_info": {
+            "drive_serial_number": "0xd215cbdb",
+            "drive_type": "DRIVE_FIXED",
+            "r_drive_type": 3,
+            "volume_id_size": 17,
+            "volume_label": "",
+            "volume_label_offset": 16
+        },
+        "volume_id_offset": 28
     },
     "target": {
-        "size": 279,
+        "index": 78,
         "items": [
             {
                 "class": "Root Folder",
-                "sort_index": "My Computer",
-                "guid": "e04fd020ea3a6910a2d808002b30309d"
+                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "sort_index": "My Computer"
             },
             {
                 "class": "Volume Item",
-                "flags": "0xf",
-                "data": "C:\\"
+                "data": "C:\\",
+                "flags": "0xf"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "1997-10-07T10:07:12+00:00",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "1997-10-07T10:07:12+00:00",
                 "primary_name": "ANONYM~1.0"
             },
             {
                 "class": "File entry",
-                "flags": "Is file",
-                "file_size": 1490944,
-                "modification_time": "1997-02-25T10:07:12+00:00",
                 "file_attribute_flags": 32,
+                "file_size": 1490944,
+                "flags": "Is file",
+                "modification_time": "1997-02-25T10:07:12+00:00",
                 "primary_name": "ANONYM~1.EXE"
             }
         ],
-        "index": 78
-    },
-    "link_info": {
-        "link_info_size": 90,
-        "link_info_header_size": 28,
-        "link_info_flags": 1,
-        "volume_id_offset": 28,
-        "local_base_path_offset": 45,
-        "common_network_relative_link_offset": 0,
-        "common_path_suffix_offset": 89,
-        "local_base_path": "C:\\AnonymusBrowser-v2.0\\AnonymusBrowser.exe",
-        "common_path_suffix": "",
-        "location": "Local",
-        "location_info": {
-            "volume_id_size": 17,
-            "r_drive_type": 3,
-            "drive_serial_number": "0xd215cbdb",
-            "volume_label_offset": 16,
-            "drive_type": "DRIVE_FIXED",
-            "volume_label": ""
-        }
-    },
-    "extra": {
-        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "size": 96,
-            "length": 88,
-            "version": 0,
-            "machine_identifier": "desktop-73cl5qt",
-            "droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
-            "droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
-            "birth_droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
-            "birth_droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e"
-        },
-        "METADATA_PROPERTIES_BLOCK": {
-            "size": 484,
-            "storage_size": 97,
-            "version": "0x53505331",
-            "format_id": "ed30bdda43008947a7f8d013a4736622"
-        }
+        "size": 279
     }
 }

--- a/tests/json/lnk_success8.lnk.json
+++ b/tests/json/lnk_success8.lnk.json
@@ -1,20 +1,38 @@
 {
+    "data": {
+        "command_line_arguments": "no_resize username=05551112233 password=123456",
+        "relative_path": ".\\AnonymusBrowser.exe",
+        "working_directory": "C:\\AnonymusBrowser-v2.0"
+    },
+    "extra": {
+        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
+            "birth_droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
+            "birth_droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
+            "droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
+            "droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
+            "length": 88,
+            "machine_identifier": "desktop-73cl5qt",
+            "size": 96,
+            "version": 0
+        },
+        "METADATA_PROPERTIES_BLOCK": {
+            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "size": 484,
+            "storage_size": 97,
+            "version": "0x53505331"
+        }
+    },
     "header": {
-        "header_size": 76,
-        "guid": "0114020000000000c000000000000046",
-        "r_link_flags": 524475,
-        "r_file_flags": 32,
-        "creation_time": "2020-07-03T22:51:57.966124+00:00",
         "accessed_time": "2020-07-06T04:18:49.803554+00:00",
-        "modified_time": "2020-07-06T04:18:49.576528+00:00",
+        "creation_time": "2020-07-03T22:51:57.966124+00:00",
+        "file_flags": [
+            "FILE_ATTRIBUTE_ARCHIVE"
+        ],
         "file_size": 1490944,
-        "icon_index": 0,
-        "windowstyle": "SW_NORMAL",
+        "guid": "0114020000000000c000000000000046",
+        "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
-        "r_hotkey": 0,
-        "reserved0": 0,
-        "reserved1": 0,
-        "reserved2": 0,
+        "icon_index": 0,
         "link_flags": [
             "HasTargetIDList",
             "HasLinkInfo",
@@ -24,83 +42,65 @@
             "IsUnicode",
             "EnableTargetMetadata"
         ],
-        "file_flags": [
-            "FILE_ATTRIBUTE_ARCHIVE"
-        ]
+        "modified_time": "2020-07-06T04:18:49.576528+00:00",
+        "r_file_flags": 32,
+        "r_hotkey": 0,
+        "r_link_flags": 524475,
+        "reserved0": 0,
+        "reserved1": 0,
+        "reserved2": 0,
+        "windowstyle": "SW_NORMAL"
     },
-    "data": {
-        "relative_path": ".\\AnonymusBrowser.exe",
-        "working_directory": "C:\\AnonymusBrowser-v2.0",
-        "command_line_arguments": "no_resize username=05551112233 password=123456"
+    "link_info": {
+        "common_network_relative_link_offset": 0,
+        "common_path_suffix": "",
+        "common_path_suffix_offset": 89,
+        "link_info_flags": 1,
+        "link_info_header_size": 28,
+        "link_info_size": 90,
+        "local_base_path": "C:\\AnonymusBrowser-v2.0\\AnonymusBrowser.exe",
+        "local_base_path_offset": 45,
+        "location": "Local",
+        "location_info": {
+            "drive_serial_number": "0xd215cbdb",
+            "drive_type": "DRIVE_FIXED",
+            "r_drive_type": 3,
+            "volume_id_size": 17,
+            "volume_label": "",
+            "volume_label_offset": 16
+        },
+        "volume_id_offset": 28
     },
     "target": {
-        "size": 279,
+        "index": 78,
         "items": [
             {
                 "class": "Root Folder",
-                "sort_index": "My Computer",
-                "guid": "e04fd020ea3a6910a2d808002b30309d"
+                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "sort_index": "My Computer"
             },
             {
                 "class": "Volume Item",
-                "flags": "0xf",
-                "data": "C:\\"
+                "data": "C:\\",
+                "flags": "0xf"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "1997-10-07T10:07:12+00:00",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "1997-10-07T10:07:12+00:00",
                 "primary_name": "ANONYM~1.0"
             },
             {
                 "class": "File entry",
-                "flags": "Is file",
-                "file_size": 1490944,
-                "modification_time": "1997-02-25T10:07:12+00:00",
                 "file_attribute_flags": 32,
+                "file_size": 1490944,
+                "flags": "Is file",
+                "modification_time": "1997-02-25T10:07:12+00:00",
                 "primary_name": "ANONYM~1.EXE"
             }
         ],
-        "index": 78
-    },
-    "link_info": {
-        "link_info_size": 90,
-        "link_info_header_size": 28,
-        "link_info_flags": 1,
-        "volume_id_offset": 28,
-        "local_base_path_offset": 45,
-        "common_network_relative_link_offset": 0,
-        "common_path_suffix_offset": 89,
-        "local_base_path": "C:\\AnonymusBrowser-v2.0\\AnonymusBrowser.exe",
-        "common_path_suffix": "",
-        "location": "Local",
-        "location_info": {
-            "volume_id_size": 17,
-            "r_drive_type": 3,
-            "drive_serial_number": "0xd215cbdb",
-            "volume_label_offset": 16,
-            "drive_type": "DRIVE_FIXED",
-            "volume_label": ""
-        }
-    },
-    "extra": {
-        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "size": 96,
-            "length": 88,
-            "version": 0,
-            "machine_identifier": "desktop-73cl5qt",
-            "droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
-            "droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
-            "birth_droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
-            "birth_droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e"
-        },
-        "METADATA_PROPERTIES_BLOCK": {
-            "size": 484,
-            "storage_size": 97,
-            "version": "0x53505331",
-            "format_id": "ed30bdda43008947a7f8d013a4736622"
-        }
+        "size": 279
     }
 }

--- a/tests/json/lnk_success8.lnk.json
+++ b/tests/json/lnk_success8.lnk.json
@@ -6,17 +6,17 @@
     },
     "extra": {
         "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "birth_droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
-            "birth_droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
-            "droid_file_identifier": "6895cc0632bfea11aba1008cfaad700e",
-            "droid_volume_identifier": "0279bf2eaaedd643a8551512e2babff2",
+            "birth_droid_file_identifier": "06CC9568-BF32-11EA-ABA1-0000FAAD700E",
+            "birth_droid_volume_identifier": "2EBF7902-EDAA-43D6-A855-0000F7BABFF2",
+            "droid_file_identifier": "06CC9568-BF32-11EA-ABA1-0000FAAD700E",
+            "droid_volume_identifier": "2EBF7902-EDAA-43D6-A855-0000F7BABFF2",
             "length": 88,
             "machine_identifier": "desktop-73cl5qt",
             "size": 96,
             "version": 0
         },
         "METADATA_PROPERTIES_BLOCK": {
-            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "format_id": "DABD30ED-0043-4789-A7F8-0000F4736622",
             "size": 484,
             "storage_size": 97,
             "version": "0x53505331"
@@ -29,7 +29,7 @@
             "FILE_ATTRIBUTE_ARCHIVE"
         ],
         "file_size": 1490944,
-        "guid": "0114020000000000c000000000000046",
+        "guid": "00021401-0000-0000-C000-000000000046",
         "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
         "icon_index": 0,
@@ -76,7 +76,7 @@
         "items": [
             {
                 "class": "Root Folder",
-                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "guid": "20D04FE0-3AEA-1069-A2D8-00002B30309D",
                 "sort_index": "My Computer"
             },
             {

--- a/tests/json/lnk_with_broken_link_info.lnk.json
+++ b/tests/json/lnk_with_broken_link_info.lnk.json
@@ -1,91 +1,91 @@
 {
+    "data": {
+        "relative_path": "..\\..\\..\\..\\..\\..\\Program Files\\xt\\xt.exe",
+        "working_directory": "C:\\Program Files\\xt"
+    },
+    "extra": {
+        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
+            "birth_droid_file_identifier": "fde6604d6cf7ea119d939a6cb2227e78",
+            "birth_droid_volume_identifier": "182a76f68e337448b4d806de16586e7a",
+            "droid_file_identifier": "fde6604d6cf7ea119d939a6cb2227e78",
+            "droid_volume_identifier": "182a76f68e337448b4d806de16586e7a",
+            "length": 88,
+            "machine_identifier": "minwinpc",
+            "size": 96,
+            "version": 0
+        },
+        "METADATA_PROPERTIES_BLOCK": {
+            "format_id": "b1166d44ad8d7048a748402ea43d788c",
+            "size": 69,
+            "storage_size": 57,
+            "version": "0x53505331"
+        }
+    },
     "header": {
-        "header_size": 76,
-        "guid": "0114020000000000c000000000000046",
-        "r_link_flags": 153,
-        "r_file_flags": 32,
-        "creation_time": "2017-03-22T05:59:50.209159+00:00",
         "accessed_time": "2020-09-15T15:58:43.317769+00:00",
-        "modified_time": "2016-06-28T08:39:33.829000+00:00",
+        "creation_time": "2017-03-22T05:59:50.209159+00:00",
+        "file_flags": [
+            "FILE_ATTRIBUTE_ARCHIVE"
+        ],
         "file_size": 40960,
-        "icon_index": 0,
-        "windowstyle": "SW_NORMAL",
+        "guid": "0114020000000000c000000000000046",
+        "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
-        "r_hotkey": 0,
-        "reserved0": 0,
-        "reserved1": 0,
-        "reserved2": 0,
+        "icon_index": 0,
         "link_flags": [
             "HasTargetIDList",
             "HasRelativePath",
             "HasWorkingDir",
             "IsUnicode"
         ],
-        "file_flags": [
-            "FILE_ATTRIBUTE_ARCHIVE"
-        ]
+        "modified_time": "2016-06-28T08:39:33.829000+00:00",
+        "r_file_flags": 32,
+        "r_hotkey": 0,
+        "r_link_flags": 153,
+        "reserved0": 0,
+        "reserved1": 0,
+        "reserved2": 0,
+        "windowstyle": "SW_NORMAL"
     },
-    "data": {
-        "relative_path": "..\\..\\..\\..\\..\\..\\Program Files\\xt\\xt.exe",
-        "working_directory": "C:\\Program Files\\xt"
-    },
+    "link_info": {},
     "target": {
-        "size": 343,
+        "index": 78,
         "items": [
             {
                 "class": "Root Folder",
-                "sort_index": "My Computer",
-                "guid": "e04fd020ea3a6910a2d808002b30309d"
+                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "sort_index": "My Computer"
             },
             {
                 "class": "Volume Item",
-                "flags": "0xf",
-                "data": "C:\\"
+                "data": "C:\\",
+                "flags": "0xf"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "2043-10-22T10:09:30+00:00",
                 "file_attribute_flags": 17,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "2043-10-22T10:09:30+00:00",
                 "primary_name": "PROGRA~1"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "2043-10-22T10:09:30+00:00",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "2043-10-22T10:09:30+00:00",
                 "primary_name": "xt"
             },
             {
                 "class": "File entry",
-                "flags": "Is file",
-                "file_size": 40960,
-                "modification_time": "2014-07-17T09:06:56+00:00",
                 "file_attribute_flags": 32,
+                "file_size": 40960,
+                "flags": "Is file",
+                "modification_time": "2014-07-17T09:06:56+00:00",
                 "primary_name": "xt.exe"
             }
         ],
-        "index": 78
-    },
-    "link_info": {},
-    "extra": {
-        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "size": 96,
-            "length": 88,
-            "version": 0,
-            "machine_identifier": "minwinpc",
-            "droid_volume_identifier": "182a76f68e337448b4d806de16586e7a",
-            "droid_file_identifier": "fde6604d6cf7ea119d939a6cb2227e78",
-            "birth_droid_volume_identifier": "182a76f68e337448b4d806de16586e7a",
-            "birth_droid_file_identifier": "fde6604d6cf7ea119d939a6cb2227e78"
-        },
-        "METADATA_PROPERTIES_BLOCK": {
-            "size": 69,
-            "storage_size": 57,
-            "version": "0x53505331",
-            "format_id": "b1166d44ad8d7048a748402ea43d788c"
-        }
+        "size": 343
     }
 }

--- a/tests/json/lnk_with_broken_link_info.lnk.json
+++ b/tests/json/lnk_with_broken_link_info.lnk.json
@@ -5,17 +5,17 @@
     },
     "extra": {
         "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "birth_droid_file_identifier": "fde6604d6cf7ea119d939a6cb2227e78",
-            "birth_droid_volume_identifier": "182a76f68e337448b4d806de16586e7a",
-            "droid_file_identifier": "fde6604d6cf7ea119d939a6cb2227e78",
-            "droid_volume_identifier": "182a76f68e337448b4d806de16586e7a",
+            "birth_droid_file_identifier": "4D60E6FD-F76C-11EA-9D93-0000BA6E7E78",
+            "birth_droid_volume_identifier": "F6762A18-338E-4874-B4D8-000016DE6E7A",
+            "droid_file_identifier": "4D60E6FD-F76C-11EA-9D93-0000BA6E7E78",
+            "droid_volume_identifier": "F6762A18-338E-4874-B4D8-000016DE6E7A",
             "length": 88,
             "machine_identifier": "minwinpc",
             "size": 96,
             "version": 0
         },
         "METADATA_PROPERTIES_BLOCK": {
-            "format_id": "b1166d44ad8d7048a748402ea43d788c",
+            "format_id": "446D16B1-8DAD-4870-A748-0000E43F788C",
             "size": 69,
             "storage_size": 57,
             "version": "0x53505331"
@@ -28,7 +28,7 @@
             "FILE_ATTRIBUTE_ARCHIVE"
         ],
         "file_size": 40960,
-        "guid": "0114020000000000c000000000000046",
+        "guid": "00021401-0000-0000-C000-000000000046",
         "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
         "icon_index": 0,
@@ -53,7 +53,7 @@
         "items": [
             {
                 "class": "Root Folder",
-                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "guid": "20D04FE0-3AEA-1069-A2D8-00002B30309D",
                 "sort_index": "My Computer"
             },
             {

--- a/tests/json/lnk_with_decoding_error.lnk.json
+++ b/tests/json/lnk_with_decoding_error.lnk.json
@@ -1,20 +1,36 @@
 {
+    "data": {
+        "relative_path": ".\\.CSV file"
+    },
+    "extra": {
+        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
+            "birth_droid_file_identifier": "64fab6945aecea119a2e30e1717a583b",
+            "birth_droid_volume_identifier": "bcba12567b8d2a4fa17aa2996cd50b5d",
+            "droid_file_identifier": "64fab6945aecea119a2e30e1717a583b",
+            "droid_volume_identifier": "bcba12567b8d2a4fa17aa2996cd50b5d",
+            "length": 88,
+            "machine_identifier": "desktop-crtgl03",
+            "size": 96,
+            "version": 0
+        },
+        "METADATA_PROPERTIES_BLOCK": {
+            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "size": 791,
+            "storage_size": 277,
+            "version": "0x53505331"
+        }
+    },
     "header": {
-        "header_size": 76,
-        "guid": "0114020000000000c000000000000046",
-        "r_link_flags": 524427,
-        "r_file_flags": 16,
-        "creation_time": "2020-09-02T10:30:21.373716+00:00",
         "accessed_time": "2020-09-02T10:46:37.463456+00:00",
-        "modified_time": "2020-09-02T10:46:37.463456+00:00",
+        "creation_time": "2020-09-02T10:30:21.373716+00:00",
+        "file_flags": [
+            "FILE_ATTRIBUTE_DIRECTORY"
+        ],
         "file_size": 4096,
-        "icon_index": 0,
-        "windowstyle": "SW_NORMAL",
+        "guid": "0114020000000000c000000000000046",
+        "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
-        "r_hotkey": 0,
-        "reserved0": 0,
-        "reserved1": 0,
-        "reserved2": 0,
+        "icon_index": 0,
         "link_flags": [
             "HasTargetIDList",
             "HasLinkInfo",
@@ -22,113 +38,97 @@
             "IsUnicode",
             "EnableTargetMetadata"
         ],
-        "file_flags": [
-            "FILE_ATTRIBUTE_DIRECTORY"
-        ]
+        "modified_time": "2020-09-02T10:46:37.463456+00:00",
+        "r_file_flags": 16,
+        "r_hotkey": 0,
+        "r_link_flags": 524427,
+        "reserved0": 0,
+        "reserved1": 0,
+        "reserved2": 0,
+        "windowstyle": "SW_NORMAL"
     },
-    "data": {
-        "relative_path": ".\\.CSV file"
+    "link_info": {
+        "common_network_relative_link_offset": 0,
+        "common_path_suffix": "",
+        "common_path_suffix_offset": 162,
+        "link_info_flags": 1,
+        "link_info_header_size": 28,
+        "link_info_size": 163,
+        "local_base_path": "C:\\Users\\Ibrahim\\Desktop\\PostDoc\\20190101 - 20191231 KU Leuven MD SPICY\\publications\\02_Majd\\Majd Py FT-IR\\.CSV file",
+        "local_base_path_offset": 45,
+        "location": "Local",
+        "location_info": {
+            "drive_serial_number": "0xc684b7e0",
+            "drive_type": "DRIVE_FIXED",
+            "r_drive_type": 3,
+            "volume_id_size": 17,
+            "volume_label": "",
+            "volume_label_offset": 16
+        },
+        "volume_id_offset": 28
     },
     "target": {
-        "size": 654,
+        "index": 78,
         "items": [
             {
                 "class": "Root Folder",
-                "sort_index": "My Computer",
-                "guid": "e04fd020ea3a6910a2d808002b30309d"
+                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "sort_index": "My Computer"
             },
             {
                 "class": "Volume Item",
-                "flags": "0xe",
-                "data": "\u0080:\u00cc\u00bf\u00b4,\u00dbLB\u00b0)\u007f\u00e9\u009a\u0087\u00c6AV"
+                "data": "\u0080:\u00cc\u00bf\u00b4,\u00dbLB\u00b0)\u007f\u00e9\u009a\u0087\u00c6AV",
+                "flags": "0xe"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "2023-07-17T09:50:10+00:00",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "2023-07-17T09:50:10+00:00",
                 "primary_name": "PostDoc"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "2025-03-27T10:07:14+00:00",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "2025-03-27T10:07:14+00:00",
                 "primary_name": "201901~1"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "Invalid time",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "Invalid time",
                 "primary_name": "PUBLIC~1"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "Invalid time",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "Invalid time",
                 "primary_name": "02_Majd"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "2063-09-05T10:09:02+00:00",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "2063-09-05T10:09:02+00:00",
                 "primary_name": "MAJDPY~1"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "Invalid time",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "Invalid time",
                 "primary_name": "CSVFIL~1"
             }
         ],
-        "index": 78
-    },
-    "link_info": {
-        "link_info_size": 163,
-        "link_info_header_size": 28,
-        "link_info_flags": 1,
-        "volume_id_offset": 28,
-        "local_base_path_offset": 45,
-        "common_network_relative_link_offset": 0,
-        "common_path_suffix_offset": 162,
-        "local_base_path": "C:\\Users\\Ibrahim\\Desktop\\PostDoc\\20190101 - 20191231 KU Leuven MD SPICY\\publications\\02_Majd\\Majd Py FT-IR\\.CSV file",
-        "common_path_suffix": "",
-        "location": "Local",
-        "location_info": {
-            "volume_id_size": 17,
-            "r_drive_type": 3,
-            "drive_serial_number": "0xc684b7e0",
-            "volume_label_offset": 16,
-            "drive_type": "DRIVE_FIXED",
-            "volume_label": ""
-        }
-    },
-    "extra": {
-        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "size": 96,
-            "length": 88,
-            "version": 0,
-            "machine_identifier": "desktop-crtgl03",
-            "droid_volume_identifier": "bcba12567b8d2a4fa17aa2996cd50b5d",
-            "droid_file_identifier": "64fab6945aecea119a2e30e1717a583b",
-            "birth_droid_volume_identifier": "bcba12567b8d2a4fa17aa2996cd50b5d",
-            "birth_droid_file_identifier": "64fab6945aecea119a2e30e1717a583b"
-        },
-        "METADATA_PROPERTIES_BLOCK": {
-            "size": 791,
-            "storage_size": 277,
-            "version": "0x53505331",
-            "format_id": "ed30bdda43008947a7f8d013a4736622"
-        }
+        "size": 654
     }
 }

--- a/tests/json/lnk_with_decoding_error.lnk.json
+++ b/tests/json/lnk_with_decoding_error.lnk.json
@@ -4,17 +4,17 @@
     },
     "extra": {
         "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "birth_droid_file_identifier": "64fab6945aecea119a2e30e1717a583b",
-            "birth_droid_volume_identifier": "bcba12567b8d2a4fa17aa2996cd50b5d",
-            "droid_file_identifier": "64fab6945aecea119a2e30e1717a583b",
-            "droid_volume_identifier": "bcba12567b8d2a4fa17aa2996cd50b5d",
+            "birth_droid_file_identifier": "94B6FA64-EC5A-11EA-9A2E-000071FB583B",
+            "birth_droid_volume_identifier": "5612BABC-8D7B-4F2A-A17A-0000EEDD0B5D",
+            "droid_file_identifier": "94B6FA64-EC5A-11EA-9A2E-000071FB583B",
+            "droid_volume_identifier": "5612BABC-8D7B-4F2A-A17A-0000EEDD0B5D",
             "length": 88,
             "machine_identifier": "desktop-crtgl03",
             "size": 96,
             "version": 0
         },
         "METADATA_PROPERTIES_BLOCK": {
-            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "format_id": "DABD30ED-0043-4789-A7F8-0000F4736622",
             "size": 791,
             "storage_size": 277,
             "version": "0x53505331"
@@ -27,7 +27,7 @@
             "FILE_ATTRIBUTE_DIRECTORY"
         ],
         "file_size": 4096,
-        "guid": "0114020000000000c000000000000046",
+        "guid": "00021401-0000-0000-C000-000000000046",
         "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
         "icon_index": 0,
@@ -72,7 +72,7 @@
         "items": [
             {
                 "class": "Root Folder",
-                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "guid": "20D04FE0-3AEA-1069-A2D8-00002B30309D",
                 "sort_index": "My Computer"
             },
             {

--- a/tests/json/lnk_with_decoding_error2.lnk.json
+++ b/tests/json/lnk_with_decoding_error2.lnk.json
@@ -1,20 +1,52 @@
 {
+    "data": {
+        "command_line_arguments": "/C .\\WindowsServices\\movemenoreg.vbs",
+        "icon_location": "%windir%\\system32\\SHELL32.dll"
+    },
+    "extra": {
+        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
+            "birth_droid_file_identifier": "f9ac30eaccb9e0118806bc5ff4204af6",
+            "birth_droid_volume_identifier": "067c1e0cf5e7c34ca6eefb36391163ac",
+            "droid_file_identifier": "f9ac30eaccb9e0118806bc5ff4204af6",
+            "droid_volume_identifier": "067c1e0cf5e7c34ca6eefb36391163ac",
+            "length": 88,
+            "machine_identifier": "dubay-\u00af\u00aa",
+            "size": 96,
+            "version": 0
+        },
+        "ENVIRONMENTAL_VARIABLES_LOCATION_BLOCK": {
+            "size": 788,
+            "target_ansi": "%COMSPEC%",
+            "target_unicode": "%"
+        },
+        "KNOWN_FOLDER_LOCATION_BLOCK": {
+            "known_folder_id": "774ec11ae7025d4eb7442eb1ae5198b7",
+            "offset": 213,
+            "size": 28
+        },
+        "METADATA_PROPERTIES_BLOCK": {
+            "format_id": "e28a5846bc4c3843bbfc139326986dce",
+            "size": 153,
+            "storage_size": 141,
+            "version": "0x53505331"
+        },
+        "SPECIAL_FOLDER_LOCATION_BLOCK": {
+            "offset": 213,
+            "size": 16,
+            "special_folder_id": 37
+        }
+    },
     "header": {
-        "header_size": 76,
-        "guid": "0114020000000000c000000000000046",
-        "r_link_flags": 739,
-        "r_file_flags": 32,
-        "creation_time": "2010-11-21T03:23:55.516901+00:00",
         "accessed_time": "2010-11-21T03:23:55.516901+00:00",
-        "modified_time": "2010-11-21T03:23:55.532502+00:00",
+        "creation_time": "2010-11-21T03:23:55.516901+00:00",
+        "file_flags": [
+            "FILE_ATTRIBUTE_ARCHIVE"
+        ],
         "file_size": 345088,
-        "icon_index": 7,
-        "windowstyle": "SW_SHOWMINNOACTIVE",
+        "guid": "0114020000000000c000000000000046",
+        "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
-        "r_hotkey": 0,
-        "reserved0": 0,
-        "reserved1": 0,
-        "reserved2": 0,
+        "icon_index": 7,
         "link_flags": [
             "HasTargetIDList",
             "HasLinkInfo",
@@ -23,105 +55,73 @@
             "IsUnicode",
             "HasExpString"
         ],
-        "file_flags": [
-            "FILE_ATTRIBUTE_ARCHIVE"
-        ]
+        "modified_time": "2010-11-21T03:23:55.532502+00:00",
+        "r_file_flags": 32,
+        "r_hotkey": 0,
+        "r_link_flags": 739,
+        "reserved0": 0,
+        "reserved1": 0,
+        "reserved2": 0,
+        "windowstyle": "SW_SHOWMINNOACTIVE"
     },
-    "data": {
-        "command_line_arguments": "/C .\\WindowsServices\\movemenoreg.vbs",
-        "icon_location": "%windir%\\system32\\SHELL32.dll"
+    "link_info": {
+        "common_network_relative_link_offset": 0,
+        "common_path_suffix": "",
+        "common_path_suffix_offset": 73,
+        "link_info_flags": 1,
+        "link_info_header_size": 28,
+        "link_info_size": 74,
+        "local_base_path": "C:\\Windows\\System32\\cmd.exe",
+        "local_base_path_offset": 45,
+        "location": "Local",
+        "location_info": {
+            "drive_serial_number": "0x42b6ef87",
+            "drive_type": "DRIVE_FIXED",
+            "r_drive_type": 3,
+            "volume_id_size": 17,
+            "volume_label": "",
+            "volume_label_offset": 16
+        },
+        "volume_id_offset": 28
     },
     "target": {
-        "size": 297,
+        "index": 78,
         "items": [
             {
                 "class": "Root Folder",
-                "sort_index": "My Computer",
-                "guid": "e04fd020ea3a6910a2d808002b30309d"
+                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "sort_index": "My Computer"
             },
             {
                 "class": "Volume Item",
-                "flags": "0xf",
-                "data": "C:\\"
+                "data": "C:\\",
+                "flags": "0xf"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "2060-11-27T07:55:56+00:00",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "2060-11-27T07:55:56+00:00",
                 "primary_name": "Windows"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "2060-06-04T07:55:56+00:00",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "2060-06-04T07:55:56+00:00",
                 "primary_name": "System32"
             },
             {
                 "class": "File entry",
-                "flags": "Is file",
-                "file_size": 345088,
-                "modification_time": "1993-07-28T07:43:42+00:00",
                 "file_attribute_flags": 32,
+                "file_size": 345088,
+                "flags": "Is file",
+                "modification_time": "1993-07-28T07:43:42+00:00",
                 "primary_name": "cmd.exe"
             }
         ],
-        "index": 78
-    },
-    "link_info": {
-        "link_info_size": 74,
-        "link_info_header_size": 28,
-        "link_info_flags": 1,
-        "volume_id_offset": 28,
-        "local_base_path_offset": 45,
-        "common_network_relative_link_offset": 0,
-        "common_path_suffix_offset": 73,
-        "local_base_path": "C:\\Windows\\System32\\cmd.exe",
-        "common_path_suffix": "",
-        "location": "Local",
-        "location_info": {
-            "volume_id_size": 17,
-            "r_drive_type": 3,
-            "drive_serial_number": "0x42b6ef87",
-            "volume_label_offset": 16,
-            "drive_type": "DRIVE_FIXED",
-            "volume_label": ""
-        }
-    },
-    "extra": {
-        "ENVIRONMENTAL_VARIABLES_LOCATION_BLOCK": {
-            "size": 788,
-            "target_ansi": "%COMSPEC%",
-            "target_unicode": "%"
-        },
-        "SPECIAL_FOLDER_LOCATION_BLOCK": {
-            "size": 16,
-            "special_folder_id": 37,
-            "offset": 213
-        },
-        "KNOWN_FOLDER_LOCATION_BLOCK": {
-            "size": 28,
-            "known_folder_id": "774ec11ae7025d4eb7442eb1ae5198b7",
-            "offset": 213
-        },
-        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "size": 96,
-            "length": 88,
-            "version": 0,
-            "machine_identifier": "dubay-\u00af\u00aa",
-            "droid_volume_identifier": "067c1e0cf5e7c34ca6eefb36391163ac",
-            "droid_file_identifier": "f9ac30eaccb9e0118806bc5ff4204af6",
-            "birth_droid_volume_identifier": "067c1e0cf5e7c34ca6eefb36391163ac",
-            "birth_droid_file_identifier": "f9ac30eaccb9e0118806bc5ff4204af6"
-        },
-        "METADATA_PROPERTIES_BLOCK": {
-            "size": 153,
-            "storage_size": 141,
-            "version": "0x53505331",
-            "format_id": "e28a5846bc4c3843bbfc139326986dce"
-        }
+        "size": 297
     }
 }

--- a/tests/json/lnk_with_decoding_error2.lnk.json
+++ b/tests/json/lnk_with_decoding_error2.lnk.json
@@ -5,10 +5,10 @@
     },
     "extra": {
         "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "birth_droid_file_identifier": "f9ac30eaccb9e0118806bc5ff4204af6",
-            "birth_droid_volume_identifier": "067c1e0cf5e7c34ca6eefb36391163ac",
-            "droid_file_identifier": "f9ac30eaccb9e0118806bc5ff4204af6",
-            "droid_volume_identifier": "067c1e0cf5e7c34ca6eefb36391163ac",
+            "birth_droid_file_identifier": "EA30ACF9-B9CC-11E0-8806-0000FC7F4AF6",
+            "birth_droid_volume_identifier": "0C1E7C06-E7F5-4CC3-A6EE-0000FB3763AC",
+            "droid_file_identifier": "EA30ACF9-B9CC-11E0-8806-0000FC7F4AF6",
+            "droid_volume_identifier": "0C1E7C06-E7F5-4CC3-A6EE-0000FB3763AC",
             "length": 88,
             "machine_identifier": "dubay-\u00af\u00aa",
             "size": 96,
@@ -20,12 +20,12 @@
             "target_unicode": "%"
         },
         "KNOWN_FOLDER_LOCATION_BLOCK": {
-            "known_folder_id": "774ec11ae7025d4eb7442eb1ae5198b7",
+            "known_folder_id": "1AC14E77-02E7-4E5D-B744-0000AEF198B7",
             "offset": 213,
             "size": 28
         },
         "METADATA_PROPERTIES_BLOCK": {
-            "format_id": "e28a5846bc4c3843bbfc139326986dce",
+            "format_id": "46588AE2-4CBC-4338-BBFC-0000379B6DCE",
             "size": 153,
             "storage_size": 141,
             "version": "0x53505331"
@@ -43,7 +43,7 @@
             "FILE_ATTRIBUTE_ARCHIVE"
         ],
         "file_size": 345088,
-        "guid": "0114020000000000c000000000000046",
+        "guid": "00021401-0000-0000-C000-000000000046",
         "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
         "icon_index": 7,
@@ -89,7 +89,7 @@
         "items": [
             {
                 "class": "Root Folder",
-                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "guid": "20D04FE0-3AEA-1069-A2D8-00002B30309D",
                 "sort_index": "My Computer"
             },
             {

--- a/tests/json/lnk_with_decoding_error3.lnk.json
+++ b/tests/json/lnk_with_decoding_error3.lnk.json
@@ -1,20 +1,39 @@
 {
+    "data": {
+        "icon_location": "%SystemRoot%\\System32\\SHELL32.dll",
+        "relative_path": ".\\Mod for Pixelmon\\Error Fix.bat",
+        "working_directory": "C:\\Users\\8<0\\Desktop\\PixelMod\\Mod for Pixelmon"
+    },
+    "extra": {
+        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
+            "birth_droid_file_identifier": "0cbffc392eedea11aef6b0fc36c1f116",
+            "birth_droid_volume_identifier": "f2189efe52d7a04b92a3382c109743b5",
+            "droid_file_identifier": "0cbffc392eedea11aef6b0fc36c1f116",
+            "droid_volume_identifier": "f2189efe52d7a04b92a3382c109743b5",
+            "length": 88,
+            "machine_identifier": "desktop-9ai08qd",
+            "size": 96,
+            "version": 0
+        },
+        "METADATA_PROPERTIES_BLOCK": {
+            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "size": 592,
+            "storage_size": 157,
+            "version": "0x53505331"
+        }
+    },
     "header": {
-        "header_size": 76,
-        "guid": "0114020000000000c000000000000046",
-        "r_link_flags": 524507,
-        "r_file_flags": 2080,
-        "creation_time": "2020-09-02T16:27:18.171371+00:00",
         "accessed_time": "2020-09-03T14:59:20.482872+00:00",
-        "modified_time": "2020-09-02T16:27:24.678487+00:00",
+        "creation_time": "2020-09-02T16:27:18.171371+00:00",
+        "file_flags": [
+            "FILE_ATTRIBUTE_ARCHIVE",
+            "FILE_ATTRIBUTE_COMPRESSED"
+        ],
         "file_size": 135,
-        "icon_index": 29,
-        "windowstyle": "SW_NORMAL",
+        "guid": "0114020000000000c000000000000046",
+        "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
-        "r_hotkey": 0,
-        "reserved0": 0,
-        "reserved1": 0,
-        "reserved2": 0,
+        "icon_index": 29,
         "link_flags": [
             "HasTargetIDList",
             "HasLinkInfo",
@@ -24,92 +43,73 @@
             "IsUnicode",
             "EnableTargetMetadata"
         ],
-        "file_flags": [
-            "FILE_ATTRIBUTE_ARCHIVE",
-            "FILE_ATTRIBUTE_COMPRESSED"
-        ]
+        "modified_time": "2020-09-02T16:27:24.678487+00:00",
+        "r_file_flags": 2080,
+        "r_hotkey": 0,
+        "r_link_flags": 524507,
+        "reserved0": 0,
+        "reserved1": 0,
+        "reserved2": 0,
+        "windowstyle": "SW_NORMAL"
     },
-    "data": {
-        "relative_path": ".\\Mod for Pixelmon\\Error Fix.bat",
-        "working_directory": "C:\\Users\\8<0\\Desktop\\PixelMod\\Mod for Pixelmon",
-        "icon_location": "%SystemRoot%\\System32\\SHELL32.dll"
+    "link_info": {
+        "common_network_relative_link_offset": 64,
+        "common_path_suffix": "\u00c4\u00e8\u00ec\u00e0\\Desktop\\PixelMod\\Mod for Pixelmon\\Error Fix.bat",
+        "common_path_suffix_offset": 108,
+        "link_info_flags": 3,
+        "link_info_header_size": 28,
+        "link_info_size": 161,
+        "local_base_path": "C:\\Users\\",
+        "local_base_path_offset": 52,
+        "location": "Local",
+        "location_info": {
+            "drive_serial_number": "0xe60d92cf",
+            "drive_type": "DRIVE_FIXED",
+            "r_drive_type": 3,
+            "volume_id_size": 24,
+            "volume_label": "Windows",
+            "volume_label_offset": 16
+        },
+        "volume_id_offset": 28
     },
     "target": {
-        "size": 380,
+        "index": 78,
         "items": [
             {
                 "class": "Root Folder",
-                "sort_index": "My Computer",
-                "guid": "e04fd020ea3a6910a2d808002b30309d"
+                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "sort_index": "My Computer"
             },
             {
                 "class": "Volume Item",
-                "flags": "0xe",
-                "data": "\u0080:\u00cc\u00bf\u00b4,\u00dbLB\u00b0)\u007f\u00e9\u009a\u0087\u00c6A&"
+                "data": "\u0080:\u00cc\u00bf\u00b4,\u00dbLB\u00b0)\u007f\u00e9\u009a\u0087\u00c6A&",
+                "flags": "0xe"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "Invalid time",
                 "file_attribute_flags": 2064,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "Invalid time",
                 "primary_name": "PixelMod"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "2039-11-26T10:09:06+00:00",
                 "file_attribute_flags": 2064,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "2039-11-26T10:09:06+00:00",
                 "primary_name": "MODFOR~1"
             },
             {
                 "class": "File entry",
-                "flags": "Is file",
-                "file_size": 135,
-                "modification_time": "2045-11-13T10:09:04+00:00",
                 "file_attribute_flags": 2080,
+                "file_size": 135,
+                "flags": "Is file",
+                "modification_time": "2045-11-13T10:09:04+00:00",
                 "primary_name": "ERRORF~1.BAT"
             }
         ],
-        "index": 78
-    },
-    "link_info": {
-        "link_info_size": 161,
-        "link_info_header_size": 28,
-        "link_info_flags": 3,
-        "volume_id_offset": 28,
-        "local_base_path_offset": 52,
-        "common_network_relative_link_offset": 64,
-        "common_path_suffix_offset": 108,
-        "local_base_path": "C:\\Users\\",
-        "common_path_suffix": "\u00c4\u00e8\u00ec\u00e0\\Desktop\\PixelMod\\Mod for Pixelmon\\Error Fix.bat",
-        "location": "Local",
-        "location_info": {
-            "volume_id_size": 24,
-            "r_drive_type": 3,
-            "drive_serial_number": "0xe60d92cf",
-            "volume_label_offset": 16,
-            "drive_type": "DRIVE_FIXED",
-            "volume_label": "Windows"
-        }
-    },
-    "extra": {
-        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "size": 96,
-            "length": 88,
-            "version": 0,
-            "machine_identifier": "desktop-9ai08qd",
-            "droid_volume_identifier": "f2189efe52d7a04b92a3382c109743b5",
-            "droid_file_identifier": "0cbffc392eedea11aef6b0fc36c1f116",
-            "birth_droid_volume_identifier": "f2189efe52d7a04b92a3382c109743b5",
-            "birth_droid_file_identifier": "0cbffc392eedea11aef6b0fc36c1f116"
-        },
-        "METADATA_PROPERTIES_BLOCK": {
-            "size": 592,
-            "storage_size": 157,
-            "version": "0x53505331",
-            "format_id": "ed30bdda43008947a7f8d013a4736622"
-        }
+        "size": 380
     }
 }

--- a/tests/json/lnk_with_decoding_error3.lnk.json
+++ b/tests/json/lnk_with_decoding_error3.lnk.json
@@ -6,17 +6,17 @@
     },
     "extra": {
         "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "birth_droid_file_identifier": "0cbffc392eedea11aef6b0fc36c1f116",
-            "birth_droid_volume_identifier": "f2189efe52d7a04b92a3382c109743b5",
-            "droid_file_identifier": "0cbffc392eedea11aef6b0fc36c1f116",
-            "droid_volume_identifier": "f2189efe52d7a04b92a3382c109743b5",
+            "birth_droid_file_identifier": "39FCBF0C-ED2E-11EA-AEF6-0000B6FDF116",
+            "birth_droid_volume_identifier": "FE9E18F2-D752-4BA0-92A3-000038BF43B5",
+            "droid_file_identifier": "39FCBF0C-ED2E-11EA-AEF6-0000B6FDF116",
+            "droid_volume_identifier": "FE9E18F2-D752-4BA0-92A3-000038BF43B5",
             "length": 88,
             "machine_identifier": "desktop-9ai08qd",
             "size": 96,
             "version": 0
         },
         "METADATA_PROPERTIES_BLOCK": {
-            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "format_id": "DABD30ED-0043-4789-A7F8-0000F4736622",
             "size": 592,
             "storage_size": 157,
             "version": "0x53505331"
@@ -30,7 +30,7 @@
             "FILE_ATTRIBUTE_COMPRESSED"
         ],
         "file_size": 135,
-        "guid": "0114020000000000c000000000000046",
+        "guid": "00021401-0000-0000-C000-000000000046",
         "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
         "icon_index": 29,
@@ -77,7 +77,7 @@
         "items": [
             {
                 "class": "Root Folder",
-                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "guid": "20D04FE0-3AEA-1069-A2D8-00002B30309D",
                 "sort_index": "My Computer"
             },
             {

--- a/tests/json/lnk_with_invalid_date.lnk.json
+++ b/tests/json/lnk_with_invalid_date.lnk.json
@@ -4,17 +4,17 @@
     },
     "extra": {
         "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "birth_droid_file_identifier": "81a3fc4755cfea11a768a0d3c124012a",
-            "birth_droid_volume_identifier": "44f84655bbda9644a6540c6775d519cb",
-            "droid_file_identifier": "81a3fc4755cfea11a768a0d3c124012a",
-            "droid_volume_identifier": "44f84655bbda9644a6540c6775d519cb",
+            "birth_droid_file_identifier": "47FCA381-CF55-11EA-A768-0000E1F7012A",
+            "birth_droid_volume_identifier": "5546F844-DABB-4496-A654-00007DF719CB",
+            "droid_file_identifier": "47FCA381-CF55-11EA-A768-0000E1F7012A",
+            "droid_volume_identifier": "5546F844-DABB-4496-A654-00007DF719CB",
             "length": 88,
             "machine_identifier": "r4pc5",
             "size": 96,
             "version": 0
         },
         "METADATA_PROPERTIES_BLOCK": {
-            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "format_id": "DABD30ED-0043-4789-A7F8-0000F4736622",
             "size": 539,
             "storage_size": 161,
             "version": "0x53505331"
@@ -28,7 +28,7 @@
             "FILE_ATTRIBUTE_DIRECTORY"
         ],
         "file_size": 4096,
-        "guid": "0114020000000000c000000000000046",
+        "guid": "00021401-0000-0000-C000-000000000046",
         "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
         "icon_index": 0,
@@ -73,7 +73,7 @@
         "items": [
             {
                 "class": "Root Folder",
-                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "guid": "20D04FE0-3AEA-1069-A2D8-00002B30309D",
                 "sort_index": "My Computer"
             },
             {

--- a/tests/json/lnk_with_invalid_date.lnk.json
+++ b/tests/json/lnk_with_invalid_date.lnk.json
@@ -1,20 +1,37 @@
 {
+    "data": {
+        "relative_path": ".\\.git"
+    },
+    "extra": {
+        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
+            "birth_droid_file_identifier": "81a3fc4755cfea11a768a0d3c124012a",
+            "birth_droid_volume_identifier": "44f84655bbda9644a6540c6775d519cb",
+            "droid_file_identifier": "81a3fc4755cfea11a768a0d3c124012a",
+            "droid_volume_identifier": "44f84655bbda9644a6540c6775d519cb",
+            "length": 88,
+            "machine_identifier": "r4pc5",
+            "size": 96,
+            "version": 0
+        },
+        "METADATA_PROPERTIES_BLOCK": {
+            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "size": 539,
+            "storage_size": 161,
+            "version": "0x53505331"
+        }
+    },
     "header": {
-        "header_size": 76,
-        "guid": "0114020000000000c000000000000046",
-        "r_link_flags": 524427,
-        "r_file_flags": 18,
-        "creation_time": "2020-07-26T08:51:06.556874+00:00",
         "accessed_time": "2020-07-26T16:14:03.203278+00:00",
-        "modified_time": "2020-07-26T08:51:09.346359+00:00",
+        "creation_time": "2020-07-26T08:51:06.556874+00:00",
+        "file_flags": [
+            "FILE_ATTRIBUTE_HIDDEN",
+            "FILE_ATTRIBUTE_DIRECTORY"
+        ],
         "file_size": 4096,
-        "icon_index": 0,
-        "windowstyle": "SW_NORMAL",
+        "guid": "0114020000000000c000000000000046",
+        "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
-        "r_hotkey": 0,
-        "reserved0": 0,
-        "reserved1": 0,
-        "reserved2": 0,
+        "icon_index": 0,
         "link_flags": [
             "HasTargetIDList",
             "HasLinkInfo",
@@ -22,98 +39,81 @@
             "IsUnicode",
             "EnableTargetMetadata"
         ],
-        "file_flags": [
-            "FILE_ATTRIBUTE_HIDDEN",
-            "FILE_ATTRIBUTE_DIRECTORY"
-        ]
+        "modified_time": "2020-07-26T08:51:09.346359+00:00",
+        "r_file_flags": 18,
+        "r_hotkey": 0,
+        "r_link_flags": 524427,
+        "reserved0": 0,
+        "reserved1": 0,
+        "reserved2": 0,
+        "windowstyle": "SW_NORMAL"
     },
-    "data": {
-        "relative_path": ".\\.git"
+    "link_info": {
+        "common_network_relative_link_offset": 0,
+        "common_path_suffix": "",
+        "common_path_suffix_offset": 116,
+        "link_info_flags": 1,
+        "link_info_header_size": 28,
+        "link_info_size": 117,
+        "local_base_path": "E:\\Razwan Ali\\REACT NATIVE\\React-Navigation-with-drawer\\.git",
+        "local_base_path_offset": 55,
+        "location": "Local",
+        "location_info": {
+            "drive_serial_number": "0x16a22e4e",
+            "drive_type": "DRIVE_FIXED",
+            "r_drive_type": 3,
+            "volume_id_size": 27,
+            "volume_label": "New Volume",
+            "volume_label_offset": 16
+        },
+        "volume_id_offset": 28
     },
     "target": {
-        "size": 473,
+        "index": 78,
         "items": [
             {
                 "class": "Root Folder",
-                "sort_index": "My Computer",
-                "guid": "e04fd020ea3a6910a2d808002b30309d"
+                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "sort_index": "My Computer"
             },
             {
                 "class": "Volume Item",
-                "flags": "0xf",
-                "data": "E:\\"
+                "data": "E:\\",
+                "flags": "0xf"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "2004-02-12T10:07:52+00:00",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "2004-02-12T10:07:52+00:00",
                 "primary_name": "Razwan Ali"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "2015-03-04T10:07:52+00:00",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "2015-03-04T10:07:52+00:00",
                 "primary_name": "REACT NATIVE"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "Invalid time",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "Invalid time",
                 "primary_name": "React-Navigation-with-drawer"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "2015-03-05T10:07:52+00:00",
                 "file_attribute_flags": 18,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "2015-03-05T10:07:52+00:00",
                 "primary_name": ".git"
             }
         ],
-        "index": 78
-    },
-    "link_info": {
-        "link_info_size": 117,
-        "link_info_header_size": 28,
-        "link_info_flags": 1,
-        "volume_id_offset": 28,
-        "local_base_path_offset": 55,
-        "common_network_relative_link_offset": 0,
-        "common_path_suffix_offset": 116,
-        "local_base_path": "E:\\Razwan Ali\\REACT NATIVE\\React-Navigation-with-drawer\\.git",
-        "common_path_suffix": "",
-        "location": "Local",
-        "location_info": {
-            "volume_id_size": 27,
-            "r_drive_type": 3,
-            "drive_serial_number": "0x16a22e4e",
-            "volume_label_offset": 16,
-            "drive_type": "DRIVE_FIXED",
-            "volume_label": "New Volume"
-        }
-    },
-    "extra": {
-        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "size": 96,
-            "length": 88,
-            "version": 0,
-            "machine_identifier": "r4pc5",
-            "droid_volume_identifier": "44f84655bbda9644a6540c6775d519cb",
-            "droid_file_identifier": "81a3fc4755cfea11a768a0d3c124012a",
-            "birth_droid_volume_identifier": "44f84655bbda9644a6540c6775d519cb",
-            "birth_droid_file_identifier": "81a3fc4755cfea11a768a0d3c124012a"
-        },
-        "METADATA_PROPERTIES_BLOCK": {
-            "size": 539,
-            "storage_size": 161,
-            "version": "0x53505331",
-            "format_id": "ed30bdda43008947a7f8d013a4736622"
-        }
+        "size": 473
     }
 }

--- a/tests/json/lnk_with_invalid_date2.lnk.json
+++ b/tests/json/lnk_with_invalid_date2.lnk.json
@@ -5,12 +5,12 @@
     },
     "extra": {
         "KNOWN_FOLDER_LOCATION_BLOCK": {
-            "known_folder_id": "774ec11ae7025d4eb7442eb1ae5198b7",
+            "known_folder_id": "1AC14E77-02E7-4E5D-B744-0000AEF198B7",
             "offset": 213,
             "size": 28
         },
         "METADATA_PROPERTIES_BLOCK": {
-            "format_id": "e28a5846bc4c3843bbfc139326986dce",
+            "format_id": "46588AE2-4CBC-4338-BBFC-0000379B6DCE",
             "size": 153,
             "storage_size": 141,
             "version": "0x53505331"
@@ -26,7 +26,7 @@
         "creation_time": "",
         "file_flags": [],
         "file_size": 0,
-        "guid": "0114020000000000c000000000000046",
+        "guid": "00021401-0000-0000-C000-000000000046",
         "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
         "icon_index": 3,
@@ -51,7 +51,7 @@
         "items": [
             {
                 "class": "Root Folder",
-                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "guid": "20D04FE0-3AEA-1069-A2D8-00002B30309D",
                 "sort_index": "My Computer"
             },
             {

--- a/tests/json/lnk_with_invalid_date2.lnk.json
+++ b/tests/json/lnk_with_invalid_date2.lnk.json
@@ -1,89 +1,89 @@
 {
+    "data": {
+        "command_line_arguments": "/c ren cfsdaacdfawd\\*.vbss *.vbs &start \\cfsdaacdfawd\\aiasfacoiaksf.vbs&start explorer .android_secure&exit",
+        "icon_location": "%SystemRoot%\\System32\\shell32.dll"
+    },
+    "extra": {
+        "KNOWN_FOLDER_LOCATION_BLOCK": {
+            "known_folder_id": "774ec11ae7025d4eb7442eb1ae5198b7",
+            "offset": 213,
+            "size": 28
+        },
+        "METADATA_PROPERTIES_BLOCK": {
+            "format_id": "e28a5846bc4c3843bbfc139326986dce",
+            "size": 153,
+            "storage_size": 141,
+            "version": "0x53505331"
+        },
+        "SPECIAL_FOLDER_LOCATION_BLOCK": {
+            "offset": 213,
+            "size": 16,
+            "special_folder_id": 37
+        }
+    },
     "header": {
-        "header_size": 76,
-        "guid": "0114020000000000c000000000000046",
-        "r_link_flags": 225,
-        "r_file_flags": 0,
-        "creation_time": "",
         "accessed_time": "",
-        "modified_time": "",
+        "creation_time": "",
+        "file_flags": [],
         "file_size": 0,
-        "icon_index": 3,
-        "windowstyle": "SW_SHOWMINNOACTIVE",
+        "guid": "0114020000000000c000000000000046",
+        "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
-        "r_hotkey": 0,
-        "reserved0": 0,
-        "reserved1": 0,
-        "reserved2": 0,
+        "icon_index": 3,
         "link_flags": [
             "HasTargetIDList",
             "HasArguments",
             "HasIconLocation",
             "IsUnicode"
         ],
-        "file_flags": []
+        "modified_time": "",
+        "r_file_flags": 0,
+        "r_hotkey": 0,
+        "r_link_flags": 225,
+        "reserved0": 0,
+        "reserved1": 0,
+        "reserved2": 0,
+        "windowstyle": "SW_SHOWMINNOACTIVE"
     },
-    "data": {
-        "command_line_arguments": "/c ren cfsdaacdfawd\\*.vbss *.vbs &start \\cfsdaacdfawd\\aiasfacoiaksf.vbs&start explorer .android_secure&exit",
-        "icon_location": "%SystemRoot%\\System32\\shell32.dll"
-    },
+    "link_info": {},
     "target": {
-        "size": 297,
+        "index": 78,
         "items": [
             {
                 "class": "Root Folder",
-                "sort_index": "My Computer",
-                "guid": "e04fd020ea3a6910a2d808002b30309d"
+                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "sort_index": "My Computer"
             },
             {
                 "class": "Volume Item",
-                "flags": "0xf",
-                "data": "C:\\"
+                "data": "C:\\",
+                "flags": "0xf"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "",
                 "primary_name": "Windows"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "",
                 "primary_name": "system32"
             },
             {
                 "class": "File entry",
-                "flags": "Is file",
-                "file_size": 0,
-                "modification_time": "",
                 "file_attribute_flags": 0,
+                "file_size": 0,
+                "flags": "Is file",
+                "modification_time": "",
                 "primary_name": "cmd.exe"
             }
         ],
-        "index": 78
-    },
-    "link_info": {},
-    "extra": {
-        "SPECIAL_FOLDER_LOCATION_BLOCK": {
-            "size": 16,
-            "special_folder_id": 37,
-            "offset": 213
-        },
-        "KNOWN_FOLDER_LOCATION_BLOCK": {
-            "size": 28,
-            "known_folder_id": "774ec11ae7025d4eb7442eb1ae5198b7",
-            "offset": 213
-        },
-        "METADATA_PROPERTIES_BLOCK": {
-            "size": 153,
-            "storage_size": 141,
-            "version": "0x53505331",
-            "format_id": "e28a5846bc4c3843bbfc139326986dce"
-        }
+        "size": 297
     }
 }

--- a/tests/json/lnk_with_invalid_date3.lnk.json
+++ b/tests/json/lnk_with_invalid_date3.lnk.json
@@ -4,17 +4,17 @@
     },
     "extra": {
         "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "birth_droid_file_identifier": "2dcdf616f1e6ea11a184706655a5c7f0",
-            "birth_droid_volume_identifier": "00000000000000000000000000000000",
-            "droid_file_identifier": "2dcdf616f1e6ea11a184706655a5c7f0",
-            "droid_volume_identifier": "00000000000000000000000000000000",
+            "birth_droid_file_identifier": "16F6CD2D-E6F1-11EA-A184-000075E7C7F0",
+            "birth_droid_volume_identifier": "00000000-0000-0000-0000-000000000000",
+            "droid_file_identifier": "16F6CD2D-E6F1-11EA-A184-000075E7C7F0",
+            "droid_volume_identifier": "00000000-0000-0000-0000-000000000000",
             "length": 88,
             "machine_identifier": "desktop-o6lerhr",
             "size": 96,
             "version": 0
         },
         "METADATA_PROPERTIES_BLOCK": {
-            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "format_id": "DABD30ED-0043-4789-A7F8-0000F4736622",
             "size": 430,
             "storage_size": 133,
             "version": "0x53505331"
@@ -28,7 +28,7 @@
             "FILE_ATTRIBUTE_DIRECTORY"
         ],
         "file_size": 4096,
-        "guid": "0114020000000000c000000000000046",
+        "guid": "00021401-0000-0000-C000-000000000046",
         "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
         "icon_index": 0,

--- a/tests/json/lnk_with_invalid_date3.lnk.json
+++ b/tests/json/lnk_with_invalid_date3.lnk.json
@@ -1,20 +1,37 @@
 {
+    "data": {
+        "relative_path": ".\\"
+    },
+    "extra": {
+        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
+            "birth_droid_file_identifier": "2dcdf616f1e6ea11a184706655a5c7f0",
+            "birth_droid_volume_identifier": "00000000000000000000000000000000",
+            "droid_file_identifier": "2dcdf616f1e6ea11a184706655a5c7f0",
+            "droid_volume_identifier": "00000000000000000000000000000000",
+            "length": 88,
+            "machine_identifier": "desktop-o6lerhr",
+            "size": 96,
+            "version": 0
+        },
+        "METADATA_PROPERTIES_BLOCK": {
+            "format_id": "ed30bdda43008947a7f8d013a4736622",
+            "size": 430,
+            "storage_size": 133,
+            "version": "0x53505331"
+        }
+    },
     "header": {
-        "header_size": 76,
-        "guid": "0114020000000000c000000000000046",
-        "r_link_flags": 524427,
-        "r_file_flags": 17,
-        "creation_time": "2020-08-25T18:03:29.341795+00:00",
         "accessed_time": "2020-09-12T15:35:19.733303+00:00",
-        "modified_time": "2020-09-11T11:46:36.453813+00:00",
+        "creation_time": "2020-08-25T18:03:29.341795+00:00",
+        "file_flags": [
+            "FILE_ATTRIBUTE_READONLY",
+            "FILE_ATTRIBUTE_DIRECTORY"
+        ],
         "file_size": 4096,
-        "icon_index": 0,
-        "windowstyle": "SW_NORMAL",
+        "guid": "0114020000000000c000000000000046",
+        "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
-        "r_hotkey": 0,
-        "reserved0": 0,
-        "reserved1": 0,
-        "reserved2": 0,
+        "icon_index": 0,
         "link_flags": [
             "HasTargetIDList",
             "HasLinkInfo",
@@ -22,64 +39,47 @@
             "IsUnicode",
             "EnableTargetMetadata"
         ],
-        "file_flags": [
-            "FILE_ATTRIBUTE_READONLY",
-            "FILE_ATTRIBUTE_DIRECTORY"
-        ]
+        "modified_time": "2020-09-11T11:46:36.453813+00:00",
+        "r_file_flags": 17,
+        "r_hotkey": 0,
+        "r_link_flags": 524427,
+        "reserved0": 0,
+        "reserved1": 0,
+        "reserved2": 0,
+        "windowstyle": "SW_NORMAL"
     },
-    "data": {
-        "relative_path": ".\\"
+    "link_info": {
+        "common_network_relative_link_offset": 0,
+        "common_path_suffix": "",
+        "common_path_suffix_offset": 77,
+        "link_info_flags": 1,
+        "link_info_header_size": 28,
+        "link_info_size": 78,
+        "local_base_path": "C:\\Users\\\u00cf\u00ee\u00eb\u00fc\u00e7\u00ee\u00e2\u00e0\u00f2\u00e5\u00eb\u00fc\\Desktop\\\u00a0",
+        "local_base_path_offset": 45,
+        "location": "Local",
+        "location_info": {
+            "drive_serial_number": "0x6f2abee",
+            "drive_type": "DRIVE_FIXED",
+            "r_drive_type": 3,
+            "volume_id_size": 17,
+            "volume_label": "",
+            "volume_label_offset": 16
+        },
+        "volume_id_offset": 28
     },
     "target": {
-        "size": 76,
+        "index": 78,
         "items": [
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "Invalid time",
                 "file_attribute_flags": 17,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "Invalid time",
                 "primary_name": "9DEC~1"
             }
         ],
-        "index": 78
-    },
-    "link_info": {
-        "link_info_size": 78,
-        "link_info_header_size": 28,
-        "link_info_flags": 1,
-        "volume_id_offset": 28,
-        "local_base_path_offset": 45,
-        "common_network_relative_link_offset": 0,
-        "common_path_suffix_offset": 77,
-        "local_base_path": "C:\\Users\\\u00cf\u00ee\u00eb\u00fc\u00e7\u00ee\u00e2\u00e0\u00f2\u00e5\u00eb\u00fc\\Desktop\\\u00a0",
-        "common_path_suffix": "",
-        "location": "Local",
-        "location_info": {
-            "volume_id_size": 17,
-            "r_drive_type": 3,
-            "drive_serial_number": "0x6f2abee",
-            "volume_label_offset": 16,
-            "drive_type": "DRIVE_FIXED",
-            "volume_label": ""
-        }
-    },
-    "extra": {
-        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "size": 96,
-            "length": 88,
-            "version": 0,
-            "machine_identifier": "desktop-o6lerhr",
-            "droid_volume_identifier": "00000000000000000000000000000000",
-            "droid_file_identifier": "2dcdf616f1e6ea11a184706655a5c7f0",
-            "birth_droid_volume_identifier": "00000000000000000000000000000000",
-            "birth_droid_file_identifier": "2dcdf616f1e6ea11a184706655a5c7f0"
-        },
-        "METADATA_PROPERTIES_BLOCK": {
-            "size": 430,
-            "storage_size": 133,
-            "version": "0x53505331",
-            "format_id": "ed30bdda43008947a7f8d013a4736622"
-        }
+        "size": 76
     }
 }

--- a/tests/json/microsoft_example.lnk.json
+++ b/tests/json/microsoft_example.lnk.json
@@ -5,10 +5,10 @@
     },
     "extra": {
         "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "birth_droid_file_identifier": "ec46cd7b227fdd11949900137216874a",
-            "birth_droid_volume_identifier": "4078c79447fac746b3565c2dc6b6d115",
-            "droid_file_identifier": "ec46cd7b227fdd11949900137216874a",
-            "droid_volume_identifier": "4078c79447fac746b3565c2dc6b6d115",
+            "birth_droid_file_identifier": "7BCD46EC-7F22-11DD-9499-00007217874A",
+            "birth_droid_volume_identifier": "94C77840-FA47-46C7-B356-0000DEBFD115",
+            "droid_file_identifier": "7BCD46EC-7F22-11DD-9499-00007217874A",
+            "droid_volume_identifier": "94C77840-FA47-46C7-B356-0000DEBFD115",
             "length": 88,
             "machine_identifier": "chris-xps",
             "size": 96,
@@ -22,7 +22,7 @@
             "FILE_ATTRIBUTE_ARCHIVE"
         ],
         "file_size": 0,
-        "guid": "0114020000000000c000000000000046",
+        "guid": "00021401-0000-0000-C000-000000000046",
         "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
         "icon_index": 0,
@@ -68,7 +68,7 @@
         "items": [
             {
                 "class": "Root Folder",
-                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "guid": "20D04FE0-3AEA-1069-A2D8-00002B30309D",
                 "sort_index": "My Computer"
             },
             {

--- a/tests/json/microsoft_example.lnk.json
+++ b/tests/json/microsoft_example.lnk.json
@@ -1,20 +1,31 @@
 {
+    "data": {
+        "relative_path": ".\\a.txt",
+        "working_directory": "C:\\test"
+    },
+    "extra": {
+        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
+            "birth_droid_file_identifier": "ec46cd7b227fdd11949900137216874a",
+            "birth_droid_volume_identifier": "4078c79447fac746b3565c2dc6b6d115",
+            "droid_file_identifier": "ec46cd7b227fdd11949900137216874a",
+            "droid_volume_identifier": "4078c79447fac746b3565c2dc6b6d115",
+            "length": 88,
+            "machine_identifier": "chris-xps",
+            "size": 96,
+            "version": 0
+        }
+    },
     "header": {
-        "header_size": 76,
-        "guid": "0114020000000000c000000000000046",
-        "r_link_flags": 524443,
-        "r_file_flags": 32,
-        "creation_time": "2008-09-12T20:27:17.101000+00:00",
         "accessed_time": "2008-09-12T20:27:17.101000+00:00",
-        "modified_time": "2008-09-12T20:27:17.101000+00:00",
+        "creation_time": "2008-09-12T20:27:17.101000+00:00",
+        "file_flags": [
+            "FILE_ATTRIBUTE_ARCHIVE"
+        ],
         "file_size": 0,
-        "icon_index": 0,
-        "windowstyle": "SW_NORMAL",
+        "guid": "0114020000000000c000000000000046",
+        "header_size": 76,
         "hotkey": "UNSET - UNSET {0x0000}",
-        "r_hotkey": 0,
-        "reserved0": 0,
-        "reserved1": 0,
-        "reserved2": 0,
+        "icon_index": 0,
         "link_flags": [
             "HasTargetIDList",
             "HasLinkInfo",
@@ -23,76 +34,65 @@
             "IsUnicode",
             "EnableTargetMetadata"
         ],
-        "file_flags": [
-            "FILE_ATTRIBUTE_ARCHIVE"
-        ]
+        "modified_time": "2008-09-12T20:27:17.101000+00:00",
+        "r_file_flags": 32,
+        "r_hotkey": 0,
+        "r_link_flags": 524443,
+        "reserved0": 0,
+        "reserved1": 0,
+        "reserved2": 0,
+        "windowstyle": "SW_NORMAL"
     },
-    "data": {
-        "relative_path": ".\\a.txt",
-        "working_directory": "C:\\test"
+    "link_info": {
+        "common_network_relative_link_offset": 0,
+        "common_path_suffix": "",
+        "common_path_suffix_offset": 59,
+        "link_info_flags": 1,
+        "link_info_header_size": 28,
+        "link_info_size": 60,
+        "local_base_path": "C:\\test\\a.txt",
+        "local_base_path_offset": 45,
+        "location": "Local",
+        "location_info": {
+            "drive_serial_number": "0x307a8a81",
+            "drive_type": "DRIVE_FIXED",
+            "r_drive_type": 3,
+            "volume_id_size": 17,
+            "volume_label": "",
+            "volume_label_offset": 16
+        },
+        "volume_id_offset": 28
     },
     "target": {
-        "size": 189,
+        "index": 78,
         "items": [
             {
                 "class": "Root Folder",
-                "sort_index": "My Computer",
-                "guid": "e04fd020ea3a6910a2d808002b30309d"
+                "guid": "e04fd020ea3a6910a2d808002b30309d",
+                "sort_index": "My Computer"
             },
             {
                 "class": "Volume Item",
-                "flags": "0xf",
-                "data": "C:\\"
+                "data": "C:\\",
+                "flags": "0xf"
             },
             {
                 "class": "File entry",
-                "flags": "Is directory",
-                "file_size": 0,
-                "modification_time": "2061-11-09T07:09:24+00:00",
                 "file_attribute_flags": 16,
+                "file_size": 0,
+                "flags": "Is directory",
+                "modification_time": "2061-11-09T07:09:24+00:00",
                 "primary_name": "test"
             },
             {
                 "class": "File entry",
-                "flags": "Is file",
-                "file_size": 0,
-                "modification_time": "2061-11-09T07:09:24+00:00",
                 "file_attribute_flags": 32,
+                "file_size": 0,
+                "flags": "Is file",
+                "modification_time": "2061-11-09T07:09:24+00:00",
                 "primary_name": "a.txt"
             }
         ],
-        "index": 78
-    },
-    "link_info": {
-        "link_info_size": 60,
-        "link_info_header_size": 28,
-        "link_info_flags": 1,
-        "volume_id_offset": 28,
-        "local_base_path_offset": 45,
-        "common_network_relative_link_offset": 0,
-        "common_path_suffix_offset": 59,
-        "local_base_path": "C:\\test\\a.txt",
-        "common_path_suffix": "",
-        "location": "Local",
-        "location_info": {
-            "volume_id_size": 17,
-            "r_drive_type": 3,
-            "drive_serial_number": "0x307a8a81",
-            "volume_label_offset": 16,
-            "drive_type": "DRIVE_FIXED",
-            "volume_label": ""
-        }
-    },
-    "extra": {
-        "DISTRIBUTED_LINK_TRACKER_BLOCK": {
-            "size": 96,
-            "length": 88,
-            "version": 0,
-            "machine_identifier": "chris-xps",
-            "droid_volume_identifier": "4078c79447fac746b3565c2dc6b6d115",
-            "droid_file_identifier": "ec46cd7b227fdd11949900137216874a",
-            "birth_droid_volume_identifier": "4078c79447fac746b3565c2dc6b6d115",
-            "birth_droid_file_identifier": "ec46cd7b227fdd11949900137216874a"
-        }
+        "size": 189
     }
 }


### PR DESCRIPTION
Two patches included:
* Sort JSON keys before touching source code so that we can easily compare GUID/hex in unified diffs.
* Remove 2 `FIXME`s.  `must_be` decorator now emit warning if something is wrong.  `uuid` decorator now return Microsoft GUID.