### PR TITLE
bugfix: Decode text data correctly

### DIFF
--- a/LnkParse3/extra/lnk_extra_base.py
+++ b/LnkParse3/extra/lnk_extra_base.py
@@ -15,17 +15,6 @@ class LnkExtraBase:
         self._raw = indata
         self.text_processor = TextProcessor(cp=cp)
 
-        # FIXME: delete
-        def _dummy(binary):
-            def clean_line(rstring):
-                return "".join(chr(i) for i in rstring if 128 > i > 20)
-            index = begin = end = 0
-            while binary[index] != 0x00:
-                end += 1
-                index += 1
-            return clean_line(binary[begin:end].replace(b"\x00", b""))
-        self.text_processor.read_unicode_string = _dummy
-
     def size(self):
         start, end = 0, 4
         size = unpack("<I", self._raw[start:end])[0]

--- a/LnkParse3/lnk_file.py
+++ b/LnkParse3/lnk_file.py
@@ -326,11 +326,13 @@ class LnkFile(object):
                 )
                 res["link_info"]["location_info"].pop("net_name_offset", None)
                 res["link_info"]["location_info"].pop("device_name_offset", None)
-            res["target"].pop("index", None)
-            if "items" in res["target"]:
-                for item in res["target"]["items"]:
-                    if item:
-                        item.pop("modification_time", None)
+
+            if "target" in res:
+                res["target"].pop("index", None)
+                if "items" in res["target"]:
+                    for item in res["target"]["items"]:
+                        if item:
+                            item.pop("modification_time", None)
 
         return res
 

--- a/LnkParse3/string_data.py
+++ b/LnkParse3/string_data.py
@@ -65,9 +65,6 @@ class StringData:
         return self._data.get("icon_location")
 
     def read(self, binary):
-        # FIXME: WRONG
-        return self._read_orig(binary)
-
         offset = 2
         char_count = unpack("<H", binary[0:offset])[0]
         length = char_count
@@ -80,21 +77,6 @@ class StringData:
 
         text = self._read(binary[offset : offset + length])
         return text, offset + length
-
-    def _read_orig(self, binary):
-        offset = 2
-
-        u_mult = 1
-        if self._lnk_file.is_unicode():
-            u_mult = 2
-
-        def clean_line(rstring):
-            return "".join(chr(i) for i in rstring if 128 > i > 20)
-
-        string_size = unpack("<H", binary[0:offset])[0] * u_mult
-        string = clean_line(binary[offset : offset + string_size].replace(b"\x00", b""))
-
-        return string, string_size + offset
 
     def as_dict(self):
         return {k: v for k, v in self._data.items() if v is not None}

--- a/LnkParse3/target/lnk_target_base.py
+++ b/LnkParse3/target/lnk_target_base.py
@@ -52,3 +52,13 @@ class LnkTargetBase:
         start, end = 0, 2
         size = unpack("<H", self._raw[start:end])[0]
         return size
+
+    def class_type_indicator(self):
+        start, end = 0, 1
+        flags = unpack("<B", self._raw_target[start:end])[0]
+        return flags
+
+    def has_unicode_strings(self):
+        inv = {v: k for k, v in self.SHELL_ITEM_SHEL_FS_FOLDER.items()}
+        mask = inv["Has Unicode strings"]
+        return bool(self.class_type_indicator() & mask)

--- a/LnkParse3/target/my_computer.py
+++ b/LnkParse3/target/my_computer.py
@@ -9,6 +9,8 @@ from LnkParse3.target.lnk_target_base import LnkTargetBase
 ----------------------------------                                   |
 |                                             ? B                    |
 ----------------------------------------------------------------------
+
+https://github.com/libyal/libfwsi/blob/master/documentation/Windows%20Shell%20Item%20format.asciidoc#33-volume-shell-item
 """
 
 
@@ -24,15 +26,20 @@ class MyComputer(LnkTargetBase):
         item["data"] = self.data()
         return item
 
-    # TODO: same as item_type in TargetFactory
-    # TODO: rename to class_type_indicator
+    # dup: ./shell_fs_folder.py flags()
+    # dup: ../target_factory.py item_type()
     def flags(self):
-        start, end = 0, 1
-        flags = unpack("<B", self._raw_target[start:end])[0]
-        return hex(flags & 0x0F)  # FIXME: delete masking
+        flags = self.class_type_indicator()
+
+        # FIXME: delete masking
+        # FIXME: hex() is only used here
+        return hex(flags & 0x0F)
 
     def data(self):
         start = 1
         binary = self._raw_target[start:]
+
+        # FIXME: Not text data
         text = self.text_processor.read_string(binary)
+
         return text

--- a/LnkParse3/target/shell_fs_folder.py
+++ b/LnkParse3/target/shell_fs_folder.py
@@ -46,10 +46,12 @@ class ShellFSFolder(LnkTargetBase):
             return None
         return item
 
-    # TODO: rename to class_type_indicator
+    # dup: ./my_computer.py flags()
+    # dup: ../target_factory.py item_type()
     def flags(self):
-        start, end = 0, 1
-        flags = unpack("<B", self._raw_target[start:end])[0]
+        flags = self.class_type_indicator()
+
+        # FIXME: delete masking
         return self.SHELL_ITEM_SHEL_FS_FOLDER[flags & 0x0F]
 
     def file_size(self):
@@ -70,11 +72,12 @@ class ShellFSFolder(LnkTargetBase):
     def primary_name(self):
         start = 12
         binary = self._raw_target[start:]
-        # FIXME: flags may contain multiple values
-        if self.flags() == "Has Unicode strings":
+
+        if self.has_unicode_strings():
             text = self.text_processor.read_unicode_string(binary)
         else:
             text = self.text_processor.read_string(binary)
+
         return text
 
     # https://github.com/libyal/libfwsi/blob/master/documentation/Windows%20Shell%20Item%20format.asciidoc#341-file-entry-shell-item--pre-windows-xp

--- a/LnkParse3/target_factory.py
+++ b/LnkParse3/target_factory.py
@@ -48,6 +48,8 @@ class TargetFactory:
         size = unpack("<H", self._raw[start:end])[0]
         return size
 
+    # dup: ./targets/shell_fs_folder.py flags()
+    # dup: ./targets/my_computer.py flags()
     def item_type(self):
         """
         Peek item type before creating objects

--- a/LnkParse3/text_processor.py
+++ b/LnkParse3/text_processor.py
@@ -29,14 +29,6 @@ class TextProcessor:
         yield from _chars_to_string(chars)
 
     def read_string(self, binary):
-        # FIXME: wrong
-        result = ""
-        for c in binary:
-            if c == 0x00:
-                break
-            result += chr(c)
-        return result
-
         it = self.read_strings(binary)
         return next(it)
 

--- a/tests/json/lnk_failing.lnk.json
+++ b/tests/json/lnk_failing.lnk.json
@@ -16,7 +16,7 @@
         "ENVIRONMENTAL_VARIABLES_LOCATION_BLOCK": {
             "size": 788,
             "target_ansi": "C:\\Users\\%USERNAME%\\AppData\\Roaming\\.minecraft",
-            "target_unicode": "C"
+            "target_unicode": "C:\\Users\\%USERNAME%\\AppData\\Roaming\\.minecraft"
         },
         "METADATA_PROPERTIES_BLOCK": {
             "format_id": "DABD30ED-0043-4789-A7F8-0000F4736622",

--- a/tests/json/lnk_failing6.lnk.json
+++ b/tests/json/lnk_failing6.lnk.json
@@ -18,7 +18,7 @@
         "ICON_LOCATION_BLOCK": {
             "size": 788,
             "target_ansi": "%SystemDrive%\\b5tcj\\e25d12f380_96.ico",
-            "target_unicode": "%"
+            "target_unicode": "%SystemDrive%\\b5tcj\\e25d12f380_96.ico"
         },
         "METADATA_PROPERTIES_BLOCK": {
             "format_id": "46588AE2-4CBC-4338-BBFC-0000379B6DCE",

--- a/tests/json/lnk_failing7.lnk.json
+++ b/tests/json/lnk_failing7.lnk.json
@@ -1,7 +1,7 @@
 {
     "data": {
-        "relative_path": "..\\..\\..\\..\\..\\..\\..\\ProgramData\\V\u001a_DJ\\V\u001a_DJ.exe",
-        "working_directory": "C:\\ProgramData\\V\u001a_DJ"
+        "relative_path": "..\\..\\..\\..\\..\\..\\..\\ProgramData\\V\u041a_DJ\\V\u041a_DJ.exe",
+        "working_directory": "C:\\ProgramData\\V\u041a_DJ"
     },
     "extra": {
         "METADATA_PROPERTIES_BLOCK": {

--- a/tests/json/lnk_success6.lnk.json
+++ b/tests/json/lnk_success6.lnk.json
@@ -18,7 +18,7 @@
         "ENVIRONMENTAL_VARIABLES_LOCATION_BLOCK": {
             "size": 788,
             "target_ansi": "%windir%\\system32\\cmd.exe",
-            "target_unicode": "%"
+            "target_unicode": "%windir%\\system32\\cmd.exe"
         },
         "KNOWN_FOLDER_LOCATION_BLOCK": {
             "known_folder_id": "1AC14E77-02E7-4E5D-B744-0000AEF198B7",

--- a/tests/json/lnk_with_decoding_error.lnk.json
+++ b/tests/json/lnk_with_decoding_error.lnk.json
@@ -77,7 +77,7 @@
             },
             {
                 "class": "Volume Item",
-                "data": "\u0080:\u00cc\u00bf\u00b4,\u00dbLB\u00b0)\u007f\u00e9\u009a\u0087\u00c6AV",
+                "data": "\u20ac:\u00cc\u00bf\u00b4,\u00dbLB\u00b0)\u007f\u00e9\u0161\u2021\u00c6AV",
                 "flags": "0xe"
             },
             {

--- a/tests/json/lnk_with_decoding_error2.lnk.json
+++ b/tests/json/lnk_with_decoding_error2.lnk.json
@@ -17,7 +17,7 @@
         "ENVIRONMENTAL_VARIABLES_LOCATION_BLOCK": {
             "size": 788,
             "target_ansi": "%COMSPEC%",
-            "target_unicode": "%"
+            "target_unicode": "%COMSPEC%"
         },
         "KNOWN_FOLDER_LOCATION_BLOCK": {
             "known_folder_id": "1AC14E77-02E7-4E5D-B744-0000AEF198B7",

--- a/tests/json/lnk_with_decoding_error3.lnk.json
+++ b/tests/json/lnk_with_decoding_error3.lnk.json
@@ -2,7 +2,7 @@
     "data": {
         "icon_location": "%SystemRoot%\\System32\\SHELL32.dll",
         "relative_path": ".\\Mod for Pixelmon\\Error Fix.bat",
-        "working_directory": "C:\\Users\\8<0\\Desktop\\PixelMod\\Mod for Pixelmon"
+        "working_directory": "C:\\Users\\\u0414\u0438\u043c\u0430\\Desktop\\PixelMod\\Mod for Pixelmon"
     },
     "extra": {
         "DISTRIBUTED_LINK_TRACKER_BLOCK": {
@@ -82,7 +82,7 @@
             },
             {
                 "class": "Volume Item",
-                "data": "\u0080:\u00cc\u00bf\u00b4,\u00dbLB\u00b0)\u007f\u00e9\u009a\u0087\u00c6A&",
+                "data": "\u20ac:\u00cc\u00bf\u00b4,\u00dbLB\u00b0)\u007f\u00e9\u0161\u2021\u00c6A&",
                 "flags": "0xe"
             },
             {

--- a/tests/json/lnk_with_invalid_date3.lnk.json
+++ b/tests/json/lnk_with_invalid_date3.lnk.json
@@ -1,6 +1,6 @@
 {
     "data": {
-        "relative_path": ".\\"
+        "relative_path": ".\\\u00a0"
     },
     "extra": {
         "DISTRIBUTED_LINK_TRACKER_BLOCK": {


### PR DESCRIPTION
The main decoding problem of this module was caused by picking ASCII-ish bytes from binary data randomly.  `clean_line` and `.replace(b"\x00", b"")` were everywhere.

In fact, Unicode strings are stored as UTF-16LE, and ASCII strings are stored as Active CodePage that defined in each Windows machines.  I added `-c/--codepage` option because we can't determine which code page was used for ASCII strings (I guess that's also why Unicode strings are also attached to LNK data structure)

Thanks