### PR TITLE
bugfix: WINDOW_STYLES[1] must be SW_SHOWNORMAL, not SW_NORMAL

### DIFF
--- a/LnkParse3/lnk_header.py
+++ b/LnkParse3/lnk_header.py
@@ -48,7 +48,7 @@ structures.
 class LnkHeader:
     # https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showwindow
     WINDOW_STYLES = {
-        1: "SW_NORMAL",  # FIXME: SW_SHOWNORMAL
+        1: "SW_SHOWNORMAL",
         3: "SW_SHOWMAXIMIZED",
         7: "SW_SHOWMINNOACTIVE",
     }

--- a/tests/json/lnk_failing.lnk.json
+++ b/tests/json/lnk_failing.lnk.json
@@ -51,7 +51,7 @@
         "reserved0": 0,
         "reserved1": 0,
         "reserved2": 0,
-        "windowstyle": "SW_NORMAL"
+        "windowstyle": "SW_SHOWNORMAL"
     },
     "link_info": {
         "common_network_relative_link_offset": 0,

--- a/tests/json/lnk_failing2.lnk.json
+++ b/tests/json/lnk_failing2.lnk.json
@@ -45,7 +45,7 @@
         "reserved0": 0,
         "reserved1": 0,
         "reserved2": 0,
-        "windowstyle": "SW_NORMAL"
+        "windowstyle": "SW_SHOWNORMAL"
     },
     "link_info": {
         "common_network_relative_link_offset": 0,

--- a/tests/json/lnk_failing3.lnk.json
+++ b/tests/json/lnk_failing3.lnk.json
@@ -28,7 +28,7 @@
         "reserved0": 0,
         "reserved1": 0,
         "reserved2": 0,
-        "windowstyle": "SW_NORMAL"
+        "windowstyle": "SW_SHOWNORMAL"
     },
     "link_info": {},
     "target": {

--- a/tests/json/lnk_failing4.lnk.json
+++ b/tests/json/lnk_failing4.lnk.json
@@ -45,7 +45,7 @@
         "reserved0": 0,
         "reserved1": 0,
         "reserved2": 0,
-        "windowstyle": "SW_NORMAL"
+        "windowstyle": "SW_SHOWNORMAL"
     },
     "link_info": {
         "common_network_relative_link_offset": 0,

--- a/tests/json/lnk_failing5.lnk.json
+++ b/tests/json/lnk_failing5.lnk.json
@@ -38,7 +38,7 @@
         "reserved0": 0,
         "reserved1": 0,
         "reserved2": 0,
-        "windowstyle": "SW_NORMAL"
+        "windowstyle": "SW_SHOWNORMAL"
     },
     "link_info": {
         "common_network_relative_link_offset": 0,

--- a/tests/json/lnk_failing7.lnk.json
+++ b/tests/json/lnk_failing7.lnk.json
@@ -33,7 +33,7 @@
         "reserved0": 0,
         "reserved1": 0,
         "reserved2": 0,
-        "windowstyle": "SW_NORMAL"
+        "windowstyle": "SW_SHOWNORMAL"
     },
     "link_info": {},
     "target": {

--- a/tests/json/lnk_success.lnk.json
+++ b/tests/json/lnk_success.lnk.json
@@ -49,7 +49,7 @@
         "reserved0": 0,
         "reserved1": 0,
         "reserved2": 0,
-        "windowstyle": "SW_NORMAL"
+        "windowstyle": "SW_SHOWNORMAL"
     },
     "link_info": {
         "common_network_relative_link_offset": 0,

--- a/tests/json/lnk_success2.lnk.json
+++ b/tests/json/lnk_success2.lnk.json
@@ -49,7 +49,7 @@
         "reserved0": 0,
         "reserved1": 0,
         "reserved2": 0,
-        "windowstyle": "SW_NORMAL"
+        "windowstyle": "SW_SHOWNORMAL"
     },
     "link_info": {
         "common_network_relative_link_offset": 0,

--- a/tests/json/lnk_success3.lnk.json
+++ b/tests/json/lnk_success3.lnk.json
@@ -56,7 +56,7 @@
         "reserved0": 0,
         "reserved1": 0,
         "reserved2": 0,
-        "windowstyle": "SW_NORMAL"
+        "windowstyle": "SW_SHOWNORMAL"
     },
     "link_info": {
         "common_network_relative_link_offset": 0,

--- a/tests/json/lnk_success4.lnk.json
+++ b/tests/json/lnk_success4.lnk.json
@@ -49,7 +49,7 @@
         "reserved0": 0,
         "reserved1": 0,
         "reserved2": 0,
-        "windowstyle": "SW_NORMAL"
+        "windowstyle": "SW_SHOWNORMAL"
     },
     "link_info": {
         "common_network_relative_link_offset": 0,

--- a/tests/json/lnk_success5.lnk.json
+++ b/tests/json/lnk_success5.lnk.json
@@ -49,7 +49,7 @@
         "reserved0": 0,
         "reserved1": 0,
         "reserved2": 0,
-        "windowstyle": "SW_NORMAL"
+        "windowstyle": "SW_SHOWNORMAL"
     },
     "link_info": {
         "common_network_relative_link_offset": 0,

--- a/tests/json/lnk_success7.lnk.json
+++ b/tests/json/lnk_success7.lnk.json
@@ -49,7 +49,7 @@
         "reserved0": 0,
         "reserved1": 0,
         "reserved2": 0,
-        "windowstyle": "SW_NORMAL"
+        "windowstyle": "SW_SHOWNORMAL"
     },
     "link_info": {
         "common_network_relative_link_offset": 0,

--- a/tests/json/lnk_success8.lnk.json
+++ b/tests/json/lnk_success8.lnk.json
@@ -49,7 +49,7 @@
         "reserved0": 0,
         "reserved1": 0,
         "reserved2": 0,
-        "windowstyle": "SW_NORMAL"
+        "windowstyle": "SW_SHOWNORMAL"
     },
     "link_info": {
         "common_network_relative_link_offset": 0,

--- a/tests/json/lnk_with_broken_link_info.lnk.json
+++ b/tests/json/lnk_with_broken_link_info.lnk.json
@@ -45,7 +45,7 @@
         "reserved0": 0,
         "reserved1": 0,
         "reserved2": 0,
-        "windowstyle": "SW_NORMAL"
+        "windowstyle": "SW_SHOWNORMAL"
     },
     "link_info": {},
     "target": {

--- a/tests/json/lnk_with_decoding_error.lnk.json
+++ b/tests/json/lnk_with_decoding_error.lnk.json
@@ -45,7 +45,7 @@
         "reserved0": 0,
         "reserved1": 0,
         "reserved2": 0,
-        "windowstyle": "SW_NORMAL"
+        "windowstyle": "SW_SHOWNORMAL"
     },
     "link_info": {
         "common_network_relative_link_offset": 0,

--- a/tests/json/lnk_with_decoding_error3.lnk.json
+++ b/tests/json/lnk_with_decoding_error3.lnk.json
@@ -50,7 +50,7 @@
         "reserved0": 0,
         "reserved1": 0,
         "reserved2": 0,
-        "windowstyle": "SW_NORMAL"
+        "windowstyle": "SW_SHOWNORMAL"
     },
     "link_info": {
         "common_network_relative_link_offset": 64,

--- a/tests/json/lnk_with_invalid_date.lnk.json
+++ b/tests/json/lnk_with_invalid_date.lnk.json
@@ -46,7 +46,7 @@
         "reserved0": 0,
         "reserved1": 0,
         "reserved2": 0,
-        "windowstyle": "SW_NORMAL"
+        "windowstyle": "SW_SHOWNORMAL"
     },
     "link_info": {
         "common_network_relative_link_offset": 0,

--- a/tests/json/lnk_with_invalid_date3.lnk.json
+++ b/tests/json/lnk_with_invalid_date3.lnk.json
@@ -46,7 +46,7 @@
         "reserved0": 0,
         "reserved1": 0,
         "reserved2": 0,
-        "windowstyle": "SW_NORMAL"
+        "windowstyle": "SW_SHOWNORMAL"
     },
     "link_info": {
         "common_network_relative_link_offset": 0,

--- a/tests/json/microsoft_example.lnk.json
+++ b/tests/json/microsoft_example.lnk.json
@@ -41,7 +41,7 @@
         "reserved0": 0,
         "reserved1": 0,
         "reserved2": 0,
-        "windowstyle": "SW_NORMAL"
+        "windowstyle": "SW_SHOWNORMAL"
     },
     "link_info": {
         "common_network_relative_link_offset": 0,


### PR DESCRIPTION
Both `SW_*` and nCmdShow values don't correspond to each other exactly.
For example, `SW_MAXIMIZE` and `SW_SHOWMAXIMIZE` have same value 3.

`[MS-SHLLINK].pdf` p.12 states that:

> ShowCommand (4 bytes): A 32-bit unsigned integer that specifies the
> expected window state of an application launched by the link. This
> value SHOULD be one of the following.
>
> * SW_SHOWNORMAL 0x00000001
>   The application is open and its window is open in a normal fashion.
>
> * SW_SHOWMAXIMIZED 0x00000003
>   The application is open, and keyboard focus is given to the application,
>   but its window is not shown.
>
> * SW_SHOWMINNOACTIVE 0x00000007
>   The application is open, but its window is not shown. It is not given
>   the keyboard focus.
>
> All other values MUST be treated as SW_SHOWNORMAL.

SEE ALSO:
https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-SHLLINK/%5bMS-SHLLINK%5d.pdf
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showwindow