### PR TITLE
Fix DOS date-time conversion

### DIFF
--- a/tests/json/broken_link_info.json
+++ b/tests/json/broken_link_info.json
@@ -66,7 +66,7 @@
                 "file_attribute_flags": 17,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2043-10-22T10:09:30+00:00",
+                "modification_time": "2020-09-15T15:58:44+00:00",
                 "primary_name": "PROGRA~1"
             },
             {
@@ -74,7 +74,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2043-10-22T10:09:30+00:00",
+                "modification_time": "2020-09-15T15:58:44+00:00",
                 "primary_name": "xt"
             },
             {
@@ -82,7 +82,7 @@
                 "file_attribute_flags": 32,
                 "file_size": 40960,
                 "flags": "Is file",
-                "modification_time": "2014-07-17T09:06:56+00:00",
+                "modification_time": "2016-06-28T08:39:34+00:00",
                 "primary_name": "xt.exe"
             }
         ],

--- a/tests/json/console_properties_block.json
+++ b/tests/json/console_properties_block.json
@@ -128,7 +128,7 @@
                 "file_attribute_flags": 48,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": null,
+                "modification_time": "2013-06-07T22:00:04+00:00",
                 "primary_name": "Windows"
             },
             {
@@ -136,7 +136,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": null,
+                "modification_time": "2013-05-24T21:47:12+00:00",
                 "primary_name": "SysWOW64"
             },
             {
@@ -144,7 +144,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": null,
+                "modification_time": "2012-07-26T08:13:00+00:00",
                 "primary_name": "WINDOW~1"
             },
             {
@@ -152,7 +152,7 @@
                 "file_attribute_flags": 20,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": null,
+                "modification_time": "2013-05-24T21:47:22+00:00",
                 "primary_name": "v1.0"
             },
             {
@@ -160,7 +160,7 @@
                 "file_attribute_flags": 32,
                 "file_size": 454656,
                 "flags": "Is file",
-                "modification_time": "1993-04-26T08:07:52+00:00",
+                "modification_time": "2012-07-26T03:20:52+00:00",
                 "primary_name": "powershell.exe"
             }
         ],

--- a/tests/json/darwin_block.json
+++ b/tests/json/darwin_block.json
@@ -65,7 +65,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "1990-12-10T10:19:20+00:00",
+                "modification_time": "2021-03-10T02:44:20+00:00",
                 "primary_name": "Windows"
             },
             {
@@ -73,7 +73,7 @@
                 "file_attribute_flags": 22,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2048-02-26T10:19:26+00:00",
+                "modification_time": "2021-03-13T17:02:52+00:00",
                 "primary_name": "Installer"
             },
             {
@@ -81,7 +81,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2048-02-26T10:19:26+00:00",
+                "modification_time": "2021-03-13T17:02:52+00:00",
                 "primary_name": "{DB8757A3-1B62-4136-8D95-D2CB9F00E36C}"
             },
             {
@@ -89,7 +89,7 @@
                 "file_attribute_flags": 33,
                 "file_size": 15406,
                 "flags": "Is file",
-                "modification_time": "2048-02-26T10:19:26+00:00",
+                "modification_time": "2021-03-13T17:02:52+00:00",
                 "primary_name": "test_icon.ico"
             }
         ],

--- a/tests/json/darwin_block_modified.json
+++ b/tests/json/darwin_block_modified.json
@@ -65,7 +65,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "1990-12-10T10:19:20+00:00",
+                "modification_time": "2021-03-10T02:44:20+00:00",
                 "primary_name": "Windows"
             },
             {
@@ -73,7 +73,7 @@
                 "file_attribute_flags": 22,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2048-02-26T10:19:26+00:00",
+                "modification_time": "2021-03-13T17:02:52+00:00",
                 "primary_name": "Installer"
             },
             {
@@ -81,7 +81,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2048-02-26T10:19:26+00:00",
+                "modification_time": "2021-03-13T17:02:52+00:00",
                 "primary_name": "{DB8757A3-1B62-4136-8D95-D2CB9F00E36C}"
             },
             {
@@ -89,7 +89,7 @@
                 "file_attribute_flags": 33,
                 "file_size": 15406,
                 "flags": "Is file",
-                "modification_time": "2048-02-26T10:19:26+00:00",
+                "modification_time": "2021-03-13T17:02:52+00:00",
                 "primary_name": "test_icon.ico"
             }
         ],

--- a/tests/json/decoding_error.json
+++ b/tests/json/decoding_error.json
@@ -85,7 +85,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2023-07-17T09:50:10+00:00",
+                "modification_time": "2019-02-05T10:55:34+00:00",
                 "primary_name": "PostDoc"
             },
             {
@@ -93,7 +93,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2025-03-27T10:07:14+00:00",
+                "modification_time": "2020-07-07T11:19:54+00:00",
                 "primary_name": "201901~1"
             },
             {
@@ -101,7 +101,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": null,
+                "modification_time": "2020-08-31T17:41:38+00:00",
                 "primary_name": "PUBLIC~1"
             },
             {
@@ -109,7 +109,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": null,
+                "modification_time": "2020-08-31T17:41:56+00:00",
                 "primary_name": "02_Majd"
             },
             {
@@ -117,7 +117,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2063-09-05T10:09:02+00:00",
+                "modification_time": "2020-09-01T20:57:10+00:00",
                 "primary_name": "MAJDPY~1"
             },
             {
@@ -125,7 +125,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": null,
+                "modification_time": "2020-09-02T10:46:38+00:00",
                 "primary_name": "CSVFIL~1"
             }
         ],

--- a/tests/json/decoding_error2.json
+++ b/tests/json/decoding_error2.json
@@ -102,7 +102,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2060-11-27T07:55:56+00:00",
+                "modification_time": "2011-07-28T20:11:54+00:00",
                 "primary_name": "Windows"
             },
             {
@@ -110,7 +110,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2060-06-04T07:55:56+00:00",
+                "modification_time": "2011-07-28T20:06:08+00:00",
                 "primary_name": "System32"
             },
             {
@@ -118,7 +118,7 @@
                 "file_attribute_flags": 32,
                 "file_size": 345088,
                 "flags": "Is file",
-                "modification_time": "1993-07-28T07:43:42+00:00",
+                "modification_time": "2010-11-21T03:23:56+00:00",
                 "primary_name": "cmd.exe"
             }
         ],

--- a/tests/json/decoding_error3.json
+++ b/tests/json/decoding_error3.json
@@ -90,7 +90,7 @@
                 "file_attribute_flags": 2064,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": null,
+                "modification_time": "2020-09-03T15:00:40+00:00",
                 "primary_name": "PixelMod"
             },
             {
@@ -98,7 +98,7 @@
                 "file_attribute_flags": 2064,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2039-11-26T10:09:06+00:00",
+                "modification_time": "2020-09-03T14:59:52+00:00",
                 "primary_name": "MODFOR~1"
             },
             {
@@ -106,7 +106,7 @@
                 "file_attribute_flags": 2080,
                 "file_size": 135,
                 "flags": "Is file",
-                "modification_time": "2045-11-13T10:09:04+00:00",
+                "modification_time": "2020-09-02T16:27:26+00:00",
                 "primary_name": "ERRORF~1.BAT"
             }
         ],

--- a/tests/json/decoding_error4.json
+++ b/tests/json/decoding_error4.json
@@ -90,7 +90,7 @@
                 "file_attribute_flags": 8208,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2054-02-21T10:06:52+00:00",
+                "modification_time": "2020-06-26T18:34:42+00:00",
                 "primary_name": "Local"
             },
             {
@@ -98,7 +98,7 @@
                 "file_attribute_flags": 8208,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2075-05-12T10:17:40+00:00",
+                "modification_time": "2021-01-20T23:53:24+00:00",
                 "primary_name": "Temp"
             },
             {
@@ -106,7 +106,7 @@
                 "file_attribute_flags": 8224,
                 "file_size": 2379344,
                 "flags": "Is file",
-                "modification_time": "2075-05-12T10:17:40+00:00",
+                "modification_time": "2021-01-20T23:53:24+00:00",
                 "primary_name": "MZDEA0~1"
             }
         ],

--- a/tests/json/invalid_date.json
+++ b/tests/json/invalid_date.json
@@ -86,7 +86,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2004-02-12T10:07:52+00:00",
+                "modification_time": "2020-07-26T06:02:24+00:00",
                 "primary_name": "Razwan Ali"
             },
             {
@@ -94,7 +94,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2015-03-04T10:07:52+00:00",
+                "modification_time": "2020-07-26T08:51:08+00:00",
                 "primary_name": "REACT NATIVE"
             },
             {
@@ -102,7 +102,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": null,
+                "modification_time": "2020-07-26T14:13:02+00:00",
                 "primary_name": "React-Navigation-with-drawer"
             },
             {
@@ -110,7 +110,7 @@
                 "file_attribute_flags": 18,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2015-03-05T10:07:52+00:00",
+                "modification_time": "2020-07-26T08:51:10+00:00",
                 "primary_name": ".git"
             }
         ],

--- a/tests/json/invalid_date3.json
+++ b/tests/json/invalid_date3.json
@@ -76,7 +76,7 @@
                 "file_attribute_flags": 17,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": null,
+                "modification_time": "2020-09-11T11:46:38+00:00",
                 "primary_name": "9DEC~1"
             }
         ],

--- a/tests/json/microsoft_example.json
+++ b/tests/json/microsoft_example.json
@@ -81,7 +81,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2061-11-09T07:09:24+00:00",
+                "modification_time": "2008-09-12T20:27:18+00:00",
                 "primary_name": "test"
             },
             {
@@ -89,7 +89,7 @@
                 "file_attribute_flags": 32,
                 "file_size": 0,
                 "flags": "Is file",
-                "modification_time": "2061-11-09T07:09:24+00:00",
+                "modification_time": "2008-09-12T20:27:18+00:00",
                 "primary_name": "a.txt"
             }
         ],

--- a/tests/json/network_info.json
+++ b/tests/json/network_info.json
@@ -85,7 +85,7 @@
                 "file_attribute_flags": 48,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2003-09-02T10:07:56+00:00",
+                "modification_time": "2020-07-28T05:57:04+00:00",
                 "primary_name": "AML24F~C"
             },
             {
@@ -93,7 +93,7 @@
                 "file_attribute_flags": 48,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2014-09-21T10:03:50+00:00",
+                "modification_time": "2020-03-25T08:41:42+00:00",
                 "primary_name": "0AQ2M9~8"
             },
             {
@@ -101,7 +101,7 @@
                 "file_attribute_flags": 48,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2027-04-17T09:59:22+00:00",
+                "modification_time": "2019-11-11T11:52:34+00:00",
                 "primary_name": "ETN"
             },
             {
@@ -109,7 +109,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2008-12-08T09:59:44+00:00",
+                "modification_time": "2019-11-22T07:12:16+00:00",
                 "primary_name": "EAH18X~X"
             },
             {
@@ -117,7 +117,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": null,
+                "modification_time": "2018-11-23T11:31:10+00:00",
                 "primary_name": "KFACY0~T"
             },
             {
@@ -125,7 +125,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": null,
+                "modification_time": "2018-11-23T11:31:10+00:00",
                 "primary_name": "LS87NY~7"
             },
             {
@@ -133,7 +133,7 @@
                 "file_attribute_flags": 32,
                 "file_size": 21895266,
                 "flags": "Is file",
-                "modification_time": null,
+                "modification_time": "2017-10-05T10:29:28+00:00",
                 "primary_name": "EWYM7F~E.PDF"
             }
         ],

--- a/tests/json/readable_with_local_info.txt
+++ b/tests/json/readable_with_local_info.txt
@@ -26,13 +26,13 @@ Windows Shortcut Information:
          File entry
             Flags: Is directory
             File size: 0
-            Modification time: 2001-06-04 10:04:32+00:00
+            Modification time: 2020-04-16 05:22:08+00:00
             File attribute flags: 48
             Primary name: Roaming
          File entry
             Flags: Is directory
             File size: 0
-            Modification time: None
+            Modification time: 2020-04-26 10:29:24+00:00
             File attribute flags: 16
             Primary name: .minecraft
 

--- a/tests/json/readable_with_network_info.txt
+++ b/tests/json/readable_with_network_info.txt
@@ -29,43 +29,43 @@ Windows Shortcut Information:
          File entry
             Flags: Is directory
             File size: 0
-            Modification time: 2003-09-02 10:07:56+00:00
+            Modification time: 2020-07-28 05:57:04+00:00
             File attribute flags: 48
             Primary name: AML24F~C
          File entry
             Flags: Is directory
             File size: 0
-            Modification time: 2014-09-21 10:03:50+00:00
+            Modification time: 2020-03-25 08:41:42+00:00
             File attribute flags: 48
             Primary name: 0AQ2M9~8
          File entry
             Flags: Is directory
             File size: 0
-            Modification time: 2027-04-17 09:59:22+00:00
+            Modification time: 2019-11-11 11:52:34+00:00
             File attribute flags: 48
             Primary name: ETN
          File entry
             Flags: Is directory
             File size: 0
-            Modification time: 2008-12-08 09:59:44+00:00
+            Modification time: 2019-11-22 07:12:16+00:00
             File attribute flags: 16
             Primary name: EAH18X~X
          File entry
             Flags: Is directory
             File size: 0
-            Modification time: None
+            Modification time: 2018-11-23 11:31:10+00:00
             File attribute flags: 16
             Primary name: KFACY0~T
          File entry
             Flags: Is directory
             File size: 0
-            Modification time: None
+            Modification time: 2018-11-23 11:31:10+00:00
             File attribute flags: 16
             Primary name: LS87NY~7
          File entry
             Flags: Is file
             File size: 21895266
-            Modification time: None
+            Modification time: 2017-10-05 10:29:28+00:00
             File attribute flags: 32
             Primary name: EWYM7F~E.PDF
 

--- a/tests/json/sample.json
+++ b/tests/json/sample.json
@@ -87,7 +87,7 @@
                 "file_attribute_flags": 48,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2001-06-04T10:04:32+00:00",
+                "modification_time": "2020-04-16T05:22:08+00:00",
                 "primary_name": "Roaming"
             },
             {
@@ -95,7 +95,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": null,
+                "modification_time": "2020-04-26T10:29:24+00:00",
                 "primary_name": ".minecraft"
             }
         ],

--- a/tests/json/sample10.json
+++ b/tests/json/sample10.json
@@ -96,7 +96,7 @@
                 "file_attribute_flags": 17,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2064-02-07T10:08:46+00:00",
+                "modification_time": "2020-08-23T21:02:14+00:00",
                 "primary_name": "PROGRA~2"
             },
             {
@@ -104,7 +104,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2064-02-08T10:08:46+00:00",
+                "modification_time": "2020-08-23T21:02:16+00:00",
                 "primary_name": "HDZB_U~1"
             },
             {
@@ -112,7 +112,7 @@
                 "file_attribute_flags": 32,
                 "file_size": 558080,
                 "flags": "Is file",
-                "modification_time": "2006-01-02T10:08:10+00:00",
+                "modification_time": "2020-08-05T06:33:04+00:00",
                 "primary_name": "HDZB_U~1.EXE"
             }
         ],

--- a/tests/json/sample11.json
+++ b/tests/json/sample11.json
@@ -89,7 +89,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "1997-10-07T10:07:12+00:00",
+                "modification_time": "2020-07-06T04:26:14+00:00",
                 "primary_name": "ANONYM~1.0"
             },
             {
@@ -97,7 +97,7 @@
                 "file_attribute_flags": 32,
                 "file_size": 1490944,
                 "flags": "Is file",
-                "modification_time": "1997-02-25T10:07:12+00:00",
+                "modification_time": "2020-07-06T04:18:50+00:00",
                 "primary_name": "ANONYM~1.EXE"
             }
         ],

--- a/tests/json/sample12.json
+++ b/tests/json/sample12.json
@@ -89,7 +89,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "1997-10-07T10:07:12+00:00",
+                "modification_time": "2020-07-06T04:26:14+00:00",
                 "primary_name": "ANONYM~1.0"
             },
             {
@@ -97,7 +97,7 @@
                 "file_attribute_flags": 32,
                 "file_size": 1490944,
                 "flags": "Is file",
-                "modification_time": "1997-02-25T10:07:12+00:00",
+                "modification_time": "2020-07-06T04:18:50+00:00",
                 "primary_name": "ANONYM~1.EXE"
             }
         ],

--- a/tests/json/sample13.json
+++ b/tests/json/sample13.json
@@ -104,7 +104,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2015-08-02T10:08:40+00:00",
+                "modification_time": "2020-08-20T08:56:04+00:00",
                 "primary_name": "Windows"
             },
             {
@@ -112,7 +112,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2008-12-15T10:08:50+00:00",
+                "modification_time": "2020-08-25T07:12:30+00:00",
                 "primary_name": "System32"
             },
             {
@@ -120,7 +120,7 @@
                 "file_attribute_flags": 32,
                 "file_size": 302592,
                 "flags": "Is file",
-                "modification_time": "1985-01-01T07:43:40+00:00",
+                "modification_time": "2010-11-20T01:17:02+00:00",
                 "primary_name": "cmd.exe"
             }
         ],

--- a/tests/json/sample14.json
+++ b/tests/json/sample14.json
@@ -89,7 +89,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "1997-10-07T10:07:12+00:00",
+                "modification_time": "2020-07-06T04:26:14+00:00",
                 "primary_name": "ANONYM~1.0"
             },
             {
@@ -97,7 +97,7 @@
                 "file_attribute_flags": 32,
                 "file_size": 1490944,
                 "flags": "Is file",
-                "modification_time": "1997-02-25T10:07:12+00:00",
+                "modification_time": "2020-07-06T04:18:50+00:00",
                 "primary_name": "ANONYM~1.EXE"
             }
         ],

--- a/tests/json/sample15.json
+++ b/tests/json/sample15.json
@@ -89,7 +89,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "1997-10-07T10:07:12+00:00",
+                "modification_time": "2020-07-06T04:26:14+00:00",
                 "primary_name": "ANONYM~1.0"
             },
             {
@@ -97,7 +97,7 @@
                 "file_attribute_flags": 32,
                 "file_size": 1490944,
                 "flags": "Is file",
-                "modification_time": "1997-02-25T10:07:12+00:00",
+                "modification_time": "2020-07-06T04:18:50+00:00",
                 "primary_name": "ANONYM~1.EXE"
             }
         ],

--- a/tests/json/sample4.json
+++ b/tests/json/sample4.json
@@ -81,7 +81,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2066-08-04T10:09:08+00:00",
+                "modification_time": "2020-09-04T21:40:08+00:00",
                 "primary_name": "Roaming"
             },
             {
@@ -89,7 +89,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": null,
+                "modification_time": "2020-09-10T19:48:40+00:00",
                 "primary_name": ".minecraft"
             }
         ],

--- a/tests/json/sample6.json
+++ b/tests/json/sample6.json
@@ -95,7 +95,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2038-01-29T08:58:10+00:00",
+                "modification_time": "2015-10-05T14:33:58+00:00",
                 "primary_name": "Youdao"
             },
             {
@@ -103,7 +103,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2038-01-29T08:58:10+00:00",
+                "modification_time": "2015-10-05T14:33:58+00:00",
                 "primary_name": "SHOPPI~1"
             },
             {
@@ -111,7 +111,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2038-01-29T08:58:10+00:00",
+                "modification_time": "2015-10-05T14:33:58+00:00",
                 "primary_name": "ie"
             },
             {
@@ -119,7 +119,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "2010-09-25T08:58:38+00:00",
+                "modification_time": "2015-10-19T07:41:50+00:00",
                 "primary_name": "4.4"
             },
             null

--- a/tests/json/sample8.json
+++ b/tests/json/sample8.json
@@ -89,7 +89,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "1997-10-07T10:07:12+00:00",
+                "modification_time": "2020-07-06T04:26:14+00:00",
                 "primary_name": "ANONYM~1.0"
             },
             {
@@ -97,7 +97,7 @@
                 "file_attribute_flags": 32,
                 "file_size": 1490944,
                 "flags": "Is file",
-                "modification_time": "1997-02-25T10:07:12+00:00",
+                "modification_time": "2020-07-06T04:18:50+00:00",
                 "primary_name": "ANONYM~1.EXE"
             }
         ],

--- a/tests/json/sample9.json
+++ b/tests/json/sample9.json
@@ -89,7 +89,7 @@
                 "file_attribute_flags": 16,
                 "file_size": 0,
                 "flags": "Is directory",
-                "modification_time": "1997-10-07T10:07:12+00:00",
+                "modification_time": "2020-07-06T04:26:14+00:00",
                 "primary_name": "ANONYM~1.0"
             },
             {
@@ -97,7 +97,7 @@
                 "file_attribute_flags": 32,
                 "file_size": 1490944,
                 "flags": "Is file",
-                "modification_time": "1997-02-25T10:07:12+00:00",
+                "modification_time": "2020-07-06T04:18:50+00:00",
                 "primary_name": "ANONYM~1.EXE"
             }
         ],


### PR DESCRIPTION
There was used a wrong order of DOS structure fields.
It is reordered based on `dfdatetime` package.