### PR TITLE
Implement as_item for unimplemented targets

### DIFF
--- a/LnkParse3/lnk_file.py
+++ b/LnkParse3/lnk_file.py
@@ -135,12 +135,9 @@ class LnkFile(object):
             cprint("Size: %s" % self.targets.id_list_size(), 2)
             cprint("Index: %s" % self._target_index, 2)
             cprint("ITEMS:", 2)
-            for target in self.targets:
-                target_item = target.as_item()
-                if target_item is None:
-                    continue
-                cprint(target_item["class"], 3)
-                for key, value in target_item.items():
+            for target in self.targets.as_list():
+                cprint(target["class"], 3)
+                for key, value in target.items():
                     if key != "class":
                         cprint(f"{nice_id(key)}: {value}", 4)
             cprint("")

--- a/LnkParse3/target/common_places_folder.py
+++ b/LnkParse3/target/common_places_folder.py
@@ -2,4 +2,11 @@ from LnkParse3.target.lnk_target_base import LnkTargetBase
 
 
 class CommonPlacesFolder(LnkTargetBase):
-    pass
+    # TODO Not implemented
+    def __init__(self, *args, **kwargs):
+        self.name = "Common places folder"
+        return super().__init__(*args, **kwargs)
+
+    def as_item(self):
+        item = super().as_item()
+        return item

--- a/LnkParse3/target/compressed_folder.py
+++ b/LnkParse3/target/compressed_folder.py
@@ -3,5 +3,11 @@ from LnkParse3.target.lnk_target_base import LnkTargetBase
 
 # https://github.com/libyal/libfwsi/blob/master/documentation/Windows%20Shell%20Item%20format.asciidoc#36-compressed-folder-shell-item
 class CompressedFolder(LnkTargetBase):
-    # TODO:
-    pass
+    # TODO Not implemented
+    def __init__(self, *args, **kwargs):
+        self.name = "Compressed folder"
+        return super().__init__(*args, **kwargs)
+
+    def as_item(self):
+        item = super().as_item()
+        return item

--- a/LnkParse3/target/control_panel.py
+++ b/LnkParse3/target/control_panel.py
@@ -4,7 +4,17 @@ from LnkParse3.decorators import uuid
 
 # https://github.com/libyal/libfwsi/blob/master/documentation/Windows%20Shell%20Item%20format.asciidoc#38-control-panel-shell-item
 class ControlPanel(LnkTargetBase):
+    # TODO Not implemented
+    def __init__(self, *args, **kwargs):
+        self.name = "Control panel"
+        return super().__init__(*args, **kwargs)
+
     @uuid
     def control_panel_item_identifier(self):
         start, end = 14, 30
         return self._raw_target[start:end]
+
+    def as_item(self):
+        item = super().as_item()
+        item["item_identifier"] = self.control_panel_item_identifier()
+        return item

--- a/LnkParse3/target/internet.py
+++ b/LnkParse3/target/internet.py
@@ -4,4 +4,11 @@ from LnkParse3.target.lnk_target_base import LnkTargetBase
 # https://github.com/libyal/libfwsi/blob/master/documentation/Windows%20Shell%20Item%20format.asciidoc#37-uri-shell-item
 # TODO: rename to uri
 class Internet(LnkTargetBase):
-    pass
+    # TODO Not implemented
+    def __init__(self, *args, **kwargs):
+        self.name = "Internet"
+        return super().__init__(*args, **kwargs)
+
+    def as_item(self):
+        item = super().as_item()
+        return item

--- a/LnkParse3/target/printers.py
+++ b/LnkParse3/target/printers.py
@@ -2,5 +2,11 @@ from LnkParse3.target.lnk_target_base import LnkTargetBase
 
 
 class Printers(LnkTargetBase):
-    # TODO:
-    pass
+    # TODO Not implemented
+    def __init__(self, *args, **kwargs):
+        self.name = "Printers"
+        return super().__init__(*args, **kwargs)
+
+    def as_item(self):
+        item = super().as_item()
+        return item

--- a/LnkParse3/target/unknown.py
+++ b/LnkParse3/target/unknown.py
@@ -2,9 +2,11 @@ from LnkParse3.target.lnk_target_base import LnkTargetBase
 
 
 class Unknown(LnkTargetBase):
+    # TODO Not implemented
     def __init__(self, *args, **kwargs):
         self.name = "Unknown"
         return super().__init__(*args, **kwargs)
 
     def as_item(self):
-        return None
+        item = super().as_item()
+        return item

--- a/LnkParse3/target/users_files_folder.py
+++ b/LnkParse3/target/users_files_folder.py
@@ -2,9 +2,11 @@ from LnkParse3.target.lnk_target_base import LnkTargetBase
 
 
 class UsersFilesFolder(LnkTargetBase):
+    # TODO Not implemented
     def __init__(self, *args, **kwargs):
         self.name = "Users files folder"
         return super().__init__(*args, **kwargs)
 
     def as_item(self):
-        return None
+        item = super().as_item()
+        return item

--- a/tests/json/decoding_error4.json
+++ b/tests/json/decoding_error4.json
@@ -84,7 +84,9 @@
                 "guid": "59031A47-3F72-44A7-89C5-5595FE6B30EE",
                 "sort_index": "Users"
             },
-            null,
+            {
+                "class": "Users files folder"
+            },
             {
                 "class": "File entry",
                 "file_attribute_flags": 8208,

--- a/tests/json/readable_with_local_info.txt
+++ b/tests/json/readable_with_local_info.txt
@@ -23,6 +23,7 @@ Windows Shortcut Information:
          Root Folder
             Sort index: Users
             Guid: 59031A47-3F72-44A7-89C5-5595FE6B30EE
+         Users files folder
          File entry
             Flags: Is directory
             File size: 0

--- a/tests/json/sample.json
+++ b/tests/json/sample.json
@@ -81,7 +81,9 @@
                 "guid": "59031A47-3F72-44A7-89C5-5595FE6B30EE",
                 "sort_index": "Users"
             },
-            null,
+            {
+                "class": "Users files folder"
+            },
             {
                 "class": "File entry",
                 "file_attribute_flags": 48,

--- a/tests/json/sample2.json
+++ b/tests/json/sample2.json
@@ -75,7 +75,9 @@
                 "guid": "59031A47-3F72-44A7-89C5-5595FE6B30EE",
                 "sort_index": "Users"
             },
-            null,
+            {
+                "class": "Users files folder"
+            },
             {
                 "class": "File entry",
                 "file_attribute_flags": 16,

--- a/tests/json/sample3.json
+++ b/tests/json/sample3.json
@@ -44,8 +44,12 @@
                 "data": "",
                 "flags": "0xe"
             },
-            null,
-            null
+            {
+                "class": "Unknown"
+            },
+            {
+                "class": "Unknown"
+            }
         ],
         "size": 2556
     }

--- a/tests/json/sample4.json
+++ b/tests/json/sample4.json
@@ -75,7 +75,9 @@
                 "guid": "59031A47-3F72-44A7-89C5-5595FE6B30EE",
                 "sort_index": "Users"
             },
-            null,
+            {
+                "class": "Users files folder"
+            },
             {
                 "class": "File entry",
                 "file_attribute_flags": 16,

--- a/tests/json/unknown_target.json
+++ b/tests/json/unknown_target.json
@@ -32,7 +32,9 @@
                 "data": "h  \u00ec!\u00ea:i\u0010\u00a2\u00dd\b",
                 "flags": "0xe"
             },
-            null
+            {
+                "class": "Unknown"
+            }
         ],
         "size": 877
     }


### PR DESCRIPTION
It will print at least target class names instead of `null` for unimplemented targets.
Also, it will give the same result for formated print and JSON.