### PR TITLE
Exclude tests from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author='Matmaus',
     author_email='matusjas.work@gmail.com',
     license='MIT',
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests*"]),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
According to [Python package guidelines](https://wiki.archlinux.org/title/Python_package_guidelines#Test_directory_in_site-package), `tests` must be excluded to prevent conflicting issues in the system.