### PR TITLE
Change extra block printing to be list agnostic and smaller

### DIFF
--- a/tests/json/readable_with_local_info.txt
+++ b/tests/json/readable_with_local_info.txt
@@ -75,58 +75,47 @@ Windows Shortcut Information:
       METADATA_PROPERTIES_BLOCK
          Size: 495
          Property store:
-            Storage:
-               Storage size: 125
-               Version: 0x53505331
-               Format id: DABD30ED-0043-4789-A7F8-D013A4736622
-               Serialized property values:
-                  Property:
-                     Value size: 97
-                     Id: 100
-                     Value: Roaming (C:\Usuários\Jonathan\AppData)
-                     Value type: VT_LPWSTR
-            Storage:
-               Storage size: 164
-               Version: 0x53505331
-               Format id: B725F130-47EF-101A-A5F1-02608C9EEBAC
-               Serialized property values:
-                  Property:
-                     Value size: 41
-                     Id: 10
-                     Value: .minecraft
-                     Value type: VT_LPWSTR
-                  Property:
-                     Value size: 21
-                     Id: 15
-                     Value: None
-                     Value type: VT_FILETIME
-                  Property:
-                     Value size: 53
-                     Id: 4
-                     Value: Pasta de arquivos
-                     Value type: VT_LPWSTR
-                  Property:
-                     Value size: 21
-                     Id: 14
-                     Value: None
-                     Value type: VT_FILETIME
-            Storage:
-               Storage size: 137
-               Version: 0x53505331
-               Format id: 28636AA6-953D-11D2-B5D6-00C04FD918D0
-               Serialized property values:
-                  Property:
-                     Value size: 109
-                     Id: 30
-                     Value: C:\Users\Jonathan\AppData\Roaming\.minecraft
-                     Value type: VT_LPWSTR
-            Storage:
-               Storage size: 57
-               Version: 0x53505331
-               Format id: 446D16B1-8DAD-4870-A748-402EA43D788C
-               Serialized property values:
-                  Property:
-                     Value size: 29
-                     Id: 104
-                     Value: None
-                     Value type: VT_CLSID
+          - Storage size: 125
+            Version: 0x53505331
+            Format id: DABD30ED-0043-4789-A7F8-D013A4736622
+            Serialized property values:
+             - Value size: 97
+               Id: 100
+               Value: Roaming (C:\Usuários\Jonathan\AppData)
+               Value type: VT_LPWSTR
+          - Storage size: 164
+            Version: 0x53505331
+            Format id: B725F130-47EF-101A-A5F1-02608C9EEBAC
+            Serialized property values:
+             - Value size: 41
+               Id: 10
+               Value: .minecraft
+               Value type: VT_LPWSTR
+             - Value size: 21
+               Id: 15
+               Value: None
+               Value type: VT_FILETIME
+             - Value size: 53
+               Id: 4
+               Value: Pasta de arquivos
+               Value type: VT_LPWSTR
+             - Value size: 21
+               Id: 14
+               Value: None
+               Value type: VT_FILETIME
+          - Storage size: 137
+            Version: 0x53505331
+            Format id: 28636AA6-953D-11D2-B5D6-00C04FD918D0
+            Serialized property values:
+             - Value size: 109
+               Id: 30
+               Value: C:\Users\Jonathan\AppData\Roaming\.minecraft
+               Value type: VT_LPWSTR
+          - Storage size: 57
+            Version: 0x53505331
+            Format id: 446D16B1-8DAD-4870-A748-402EA43D788C
+            Serialized property values:
+             - Value size: 29
+               Id: 104
+               Value: None
+               Value type: VT_CLSID

--- a/tests/json/readable_with_network_info.txt
+++ b/tests/json/readable_with_network_info.txt
@@ -103,53 +103,43 @@ Windows Shortcut Information:
       METADATA_PROPERTIES_BLOCK
          Size: 955
          Property store:
-            Storage:
-               Storage size: 229
-               Version: 0x53505331
-               Format id: B725F130-47EF-101A-A5F1-02608C9EEBAC
-               Serialized property values:
-                  Property:
-                     Value size: 73
-                     Id: 10
-                     Value: ETN-lift programme 2017.pdf
-                     Value type: VT_LPWSTR
-                  Property:
-                     Value size: 21
-                     Id: 15
-                     Value: None
-                     Value type: VT_FILETIME
-                  Property:
-                     Value size: 21
-                     Id: 12
-                     Value: None
-                     Value type: VT_UI8
-                  Property:
-                     Value size: 65
-                     Id: 4
-                     Value: Adobe Acrobat Document
-                     Value type: VT_LPWSTR
-                  Property:
-                     Value size: 21
-                     Id: 14
-                     Value: None
-                     Value type: VT_FILETIME
-            Storage:
-               Storage size: 385
-               Version: 0x53505331
-               Format id: 28636AA6-953D-11D2-B5D6-00C04FD918D0
-               Serialized property values:
-                  Property:
-                     Value size: 357
-                     Id: 30
-                     Value: Z:\A - LM METAL LIFT\01.OBCHOD - BROŽURY - Prodejní a technické informace o produktech\ETN\ETN-Katalog-ENG\Katalog ETN 10_2017\Lift-programme\ETN-lift programme 2017.pdf
-                     Value type: VT_LPWSTR
-            Storage:
-               Storage size: 329
-               Version: 0x53505331
-               Format id: E3E0584C-B788-4A5A-BB20-7F5A44C9ACDD
-               Serialized property values:
-                  Property:
-                     Value size: 301
-                     Id: 6
-                     Value: Z:\A - LM METAL LIFT\01.OBCHOD - BROŽURY - Prodejní a technické informace o produktech\ETN\ETN-Katalog-ENG\Katalog ETN 10_2017\Lift-programme
-                     Value type: VT_LPWSTR
+          - Storage size: 229
+            Version: 0x53505331
+            Format id: B725F130-47EF-101A-A5F1-02608C9EEBAC
+            Serialized property values:
+             - Value size: 73
+               Id: 10
+               Value: ETN-lift programme 2017.pdf
+               Value type: VT_LPWSTR
+             - Value size: 21
+               Id: 15
+               Value: None
+               Value type: VT_FILETIME
+             - Value size: 21
+               Id: 12
+               Value: None
+               Value type: VT_UI8
+             - Value size: 65
+               Id: 4
+               Value: Adobe Acrobat Document
+               Value type: VT_LPWSTR
+             - Value size: 21
+               Id: 14
+               Value: None
+               Value type: VT_FILETIME
+          - Storage size: 385
+            Version: 0x53505331
+            Format id: 28636AA6-953D-11D2-B5D6-00C04FD918D0
+            Serialized property values:
+             - Value size: 357
+               Id: 30
+               Value: Z:\A - LM METAL LIFT\01.OBCHOD - BROŽURY - Prodejní a technické informace o produktech\ETN\ETN-Katalog-ENG\Katalog ETN 10_2017\Lift-programme\ETN-lift programme 2017.pdf
+               Value type: VT_LPWSTR
+          - Storage size: 329
+            Version: 0x53505331
+            Format id: E3E0584C-B788-4A5A-BB20-7F5A44C9ACDD
+            Serialized property values:
+             - Value size: 301
+               Id: 6
+               Value: Z:\A - LM METAL LIFT\01.OBCHOD - BROŽURY - Prodejní a technické informace o produktech\ETN\ETN-Katalog-ENG\Katalog ETN 10_2017\Lift-programme
+               Value type: VT_LPWSTR

--- a/tests/json/unknown_block.txt
+++ b/tests/json/unknown_block.txt
@@ -55,9 +55,7 @@ Windows Shortcut Information:
          Special folder id: 37
          Offset: 213
       UNKNOWN_BLOCK
-         Block:
-            Size: 28
-            Extra data sha256: 4f022b4bc7668d870e158010c9877224df1b9b07bd24ef32b731963232b15eb2
-         Block:
-            Size: 153
-            Extra data sha256: 40ebe6ee6ad3303ae2db241742e857aee523b21553a51e2f6c2a2461f1010879
+       - Size: 28
+         Extra data sha256: 4f022b4bc7668d870e158010c9877224df1b9b07bd24ef32b731963232b15eb2
+       - Size: 153
+         Extra data sha256: 40ebe6ee6ad3303ae2db241742e857aee523b21553a51e2f6c2a2461f1010879


### PR DESCRIPTION
As we discussed, that would be the modification to make the print more list agnostic and more yaml-like for Extra blocks. I would totally understand if you consider it to be too convoluted and creating too much complexity for the benefit. I think that by making this PR, even if you chose not to take it in and I delete my repo, it'll stay for future references? Maybe it will be revisited if LnkParse3's Extra Block management keep growing into handling more odd undocumented edge cases. 🙂