### PR TITLE
Fix LNK Parsing Error in Specific Cases in string_data.py

### DIFF
--- a/LnkParse3/string_data.py
+++ b/LnkParse3/string_data.py
@@ -25,17 +25,17 @@ class StringData:
         start = 0
         try:
             if self._lnk_file.has_name():
-                text, length = self.read(self._raw[start:])
+                text, length = self.read(self._raw[start:], limit_length=True)
                 self._data["description"] = text
                 start += length
 
             if self._lnk_file.has_relative_path():
-                text, length = self.read(self._raw[start:])
+                text, length = self.read(self._raw[start:], limit_length=True)
                 self._data["relative_path"] = text
                 start += length
 
             if self._lnk_file.has_working_dir():
-                text, length = self.read(self._raw[start:])
+                text, length = self.read(self._raw[start:], limit_length=True)
                 self._data["working_directory"] = text
                 start += length
 
@@ -71,10 +71,10 @@ class StringData:
     def icon_location(self):
         return self._data.get("icon_location")
 
-    def read(self, binary):
+    def read(self, binary, limit_length=False):
         offset = 2
         char_count = unpack("<H", binary[0:offset])[0]
-        length = char_count
+        length = 260 if limit_length and char_count > 260 else char_count
 
         if self._lnk_file.is_unicode():
             self._read = self.text_processor.read_unicode_string


### PR DESCRIPTION
Hi,
I came across several LNK files that are not parsed correctly by your library, as well as by many other parsers. The issue lies in the `StringData` class.

The class assumes that the 2 bytes (`str_length`) preceding each string accurately reflect the number of characters. However, it turns out that `str_length` can contain large values (e.g., `0xFFFF`), while Windows internally enforces a 260-character limit (520 bytes in Unicode) on certain strings within the LNK format.

This behavior applies to the strings `name`, `relative_path`, and `working_dir`, which correspond to the flags `HasName`, `HasRelativePath`, and `HasWorkingDir`.

I've attached files that demonstrate the issue (you can check all of them by right-clicking):

* `original.lnk` – a regular file without any parsing problems

* `name_long_ok.lnk` – same file, but with a name string exactly 260 characters long. **Note that Windows treats the last character as null, even if it's a valid letter (as in this file).**

* `name_broken.lnk` – here the name string is 261 characters long and breaks the following `relative_path` string

* `relative_path_long_ok.lnk` – similar case for `relative_path`

* `relative_path_long_broken.lnk` – 261 bytes in `relative_path` corrupt the next string workdir

* `workdir_long_ok.lnk` and `workdir_long_broken.lnk` – similar issue, the `arguments` string gets corrupted

The arguments string, associated with the `HasArguments` flag, does not appear to have this 260-character limitation (which makes sense).

Files are here: [test.zip](https://github.com/user-attachments/files/19556377/test.zip)